### PR TITLE
修复 macOS Intel 发布构建

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
             args: --target aarch64-apple-darwin --bundles dmg
             appleSigningIdentity: "-"
           - name: macOS Intel
-            platform: macos-latest
+            platform: macos-15-intel
             rustTargets: x86_64-apple-darwin
             args: --target x86_64-apple-darwin --bundles dmg
             appleSigningIdentity: "-"


### PR DESCRIPTION
## 修改

- 将 macOS Intel 发布任务切换到官方 `macos-15-intel` x64 运行器
- 保持 Apple Silicon、Linux 和 Windows 构建配置不变

## 原因

`macos-latest` 当前为 ARM64，交叉编译 x86_64 时 `openssl-sys` 无法找到 Intel OpenSSL。使用原生 Intel 运行器可避免该架构依赖问题。

## 验证

- `git diff --check`
- `bun run release:check v0.1.0`
- `bun run release:notes v0.1.0`