### PR TITLE
修复 macOS 发布依赖校验

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,9 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.rustTargets }}
         run: |
-          binary="src-tauri/target/$RUST_TARGET/release/bundle/macos/FineShell.app/Contents/MacOS/fineshell"
+          # Tauri removes the temporary .app after creating the DMG, while the
+          # linked release executable remains available for dependency checks.
+          binary="src-tauri/target/$RUST_TARGET/release/fineshell"
           if [[ ! -x "$binary" ]]; then
             echo "macOS application binary not found: $binary" >&2
             exit 1


### PR DESCRIPTION
## 变更
- 改为校验 Tauri 构建后保留的 release 可执行文件
- 避免 DMG 打包清理临时 `.app` 后产生误报

## 验证
- 工作流 YAML 解析通过
- 本地 release 可执行文件动态依赖校验通过
- `git diff --check` 通过