### PR TITLE
发布 FineShell 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本文件记录 FineShell 各版本的重要变更。版本号遵循[语义化版本](https://semver.org/lang/zh-CN/)。
 
-## [Unreleased]
+## [0.1.5] - 2026-07-26
 
 ### 修复
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fineshell",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fineshell"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "fast-socks5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fineshell"
-version = "0.1.4"
+version = "0.1.5"
 description = "A cross-platform SSH and SFTP client for terminal access, file management, and server monitoring."
 authors = ["Max"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FineShell",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.fineshell.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## 变更

- 将 FineShell 版本升级至 0.1.5
- 发布更新清单公开下载地址修复
- 更新 CHANGELOG 发布说明

## 验证

- `bun test`（120 项通过）
- `bun run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`（60 项通过，8 项在线测试忽略）
- `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked --target x86_64-pc-windows-gnu --tests`
- `bun scripts/check-release-version.ts v0.1.5`