### PR TITLE
修复草稿版本发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,14 +184,22 @@ jobs:
           gh release download "$RELEASE_TAG" \
             --pattern latest.json \
             --dir "$RUNNER_TEMP/updater"
+          release_id="$(
+            gh release view "$RELEASE_TAG" \
+              --json databaseId \
+              --jq '.databaseId'
+          )"
           gh api \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" \
             > "$RUNNER_TEMP/updater/release.json"
       - name: Normalize updater download URLs
         run: |
           bun scripts/normalize-updater-manifest.ts \
             "$RUNNER_TEMP/updater/latest.json" \
-            "$RUNNER_TEMP/updater/release.json"
+            "$RUNNER_TEMP/updater/release.json" \
+            "$RELEASE_TAG"
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
       - name: Validate updater manifest
         env:
           RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}

--- a/scripts/normalize-updater-manifest.test.ts
+++ b/scripts/normalize-updater-manifest.test.ts
@@ -25,6 +25,7 @@ describe("updater manifest URL normalization", () => {
           },
         ],
       },
+      "v1.2.3",
     );
 
     expect(result.normalizedKeys).toEqual(["darwin-aarch64"]);
@@ -46,13 +47,40 @@ describe("updater manifest URL normalization", () => {
           },
         },
         { assets: [] },
+        "v1.2.3",
       ),
     ).toThrow("找不到对应的公开下载地址");
   });
 
   test("rejects malformed release metadata", () => {
     expect(() =>
-      normalizeUpdaterManifestUrls({ platforms: {} }, {}),
+      normalizeUpdaterManifestUrls({ platforms: {} }, {}, "v1.2.3"),
     ).toThrow("缺少 assets 数组");
+  });
+
+  test("replaces draft release paths with the intended tag", () => {
+    const result = normalizeUpdaterManifestUrls(
+      {
+        platforms: {
+          "darwin-aarch64": { signature: "signed", url: apiUrl },
+        },
+      },
+      {
+        assets: [
+          {
+            browser_download_url:
+              "https://github.com/example/app/releases/download/untagged-draft/app.tar.gz",
+            url: apiUrl,
+          },
+        ],
+      },
+      "v1.2.3",
+    );
+
+    expect(result.manifest).toEqual({
+      platforms: {
+        "darwin-aarch64": { signature: "signed", url: publicUrl },
+      },
+    });
   });
 });

--- a/scripts/normalize-updater-manifest.ts
+++ b/scripts/normalize-updater-manifest.ts
@@ -56,11 +56,34 @@ function releaseAssetUrls(value: unknown) {
   return urls;
 }
 
+function stableReleaseDownloadUrl(value: string, releaseTag: string) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("GitHub Release 公开下载地址无效");
+  }
+
+  const match = url.pathname.match(
+    /^\/([^/]+)\/([^/]+)\/releases\/download\/[^/]+\/([^/]+)$/,
+  );
+  if (url.hostname !== "github.com" || !match) {
+    throw new Error("GitHub Release 公开下载地址格式无效");
+  }
+
+  const [, owner, repository, fileName] = match;
+  return `https://github.com/${owner}/${repository}/releases/download/${releaseTag}/${fileName}`;
+}
+
 export function normalizeUpdaterManifestUrls(
   value: unknown,
   releaseValue: unknown,
+  releaseTag: string,
 ) {
   if (!isRecord(value)) throw new Error("更新清单格式无效");
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(releaseTag)) {
+    throw new Error(`版本标签“${releaseTag}”格式无效`);
+  }
 
   const manifest = value as UpdaterManifest;
   if (!isRecord(manifest.platforms)) {
@@ -83,12 +106,15 @@ export function normalizeUpdaterManifestUrls(
       return;
     }
 
-    const publicUrl = assetUrls.get(platform.url);
-    if (!publicUrl) {
+    const assetUrl = assetUrls.get(platform.url);
+    if (!assetUrl) {
       throw new Error(`更新清单平台 ${key} 找不到对应的公开下载地址`);
     }
 
-    normalizedPlatforms[key] = { ...value, url: publicUrl };
+    normalizedPlatforms[key] = {
+      ...value,
+      url: stableReleaseDownloadUrl(assetUrl, releaseTag),
+    };
     normalizedKeys.push(key);
   });
 
@@ -102,12 +128,18 @@ if (import.meta.main) {
   try {
     const manifestPath = process.argv[2];
     const releasePath = process.argv[3];
+    const releaseTag = process.argv[4] ?? "";
     if (!manifestPath) throw new Error("缺少 latest.json 路径");
     if (!releasePath) throw new Error("缺少 GitHub Release 元数据路径");
+    if (!releaseTag) throw new Error("缺少版本标签");
 
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     const release = JSON.parse(readFileSync(releasePath, "utf8"));
-    const normalized = normalizeUpdaterManifestUrls(manifest, release);
+    const normalized = normalizeUpdaterManifestUrls(
+      manifest,
+      release,
+      releaseTag,
+    );
     writeFileSync(
       manifestPath,
       `${JSON.stringify(normalized.manifest, null, 2)}\n`,

--- a/scripts/validate-updater-manifest.test.ts
+++ b/scripts/validate-updater-manifest.test.ts
@@ -79,6 +79,20 @@ describe("updater manifest validation", () => {
         }),
         "v1.2.3",
       ),
-    ).toThrow("必须使用 GitHub Release 公开下载地址");
+    ).toThrow("必须使用当前版本的 GitHub Release 公开下载地址");
+  });
+
+  test("rejects draft release download paths", () => {
+    expect(() =>
+      validateUpdaterManifest(
+        manifest({
+          "darwin-aarch64": {
+            ...platform,
+            url: "https://github.com/example/app/releases/download/untagged-draft/app.tar.gz",
+          },
+        }),
+        "v1.2.3",
+      ),
+    ).toThrow("必须使用当前版本的 GitHub Release 公开下载地址");
   });
 });

--- a/scripts/validate-updater-manifest.ts
+++ b/scripts/validate-updater-manifest.ts
@@ -44,7 +44,7 @@ function expectedVersionFromTag(releaseTag: string) {
   return releaseTag.slice(1);
 }
 
-function validatePlatform(key: string, value: unknown) {
+function validatePlatform(key: string, value: unknown, releaseTag: string) {
   if (!isRecord(value)) {
     throw new Error(`更新清单平台 ${key} 格式无效`);
   }
@@ -66,12 +66,12 @@ function validatePlatform(key: string, value: unknown) {
   if (url.protocol !== "https:") {
     throw new Error(`更新清单平台 ${key} 的下载地址必须使用 HTTPS`);
   }
-  if (
-    url.hostname !== "github.com" ||
-    !/^\/[^/]+\/[^/]+\/releases\/download\/[^/]+\/[^/]+$/.test(url.pathname)
-  ) {
+  const match = url.pathname.match(
+    /^\/[^/]+\/[^/]+\/releases\/download\/([^/]+)\/[^/]+$/,
+  );
+  if (url.hostname !== "github.com" || !match || match[1] !== releaseTag) {
     throw new Error(
-      `更新清单平台 ${key} 必须使用 GitHub Release 公开下载地址`,
+      `更新清单平台 ${key} 必须使用当前版本的 GitHub Release 公开下载地址`,
     );
   }
 }
@@ -94,7 +94,7 @@ export function validateUpdaterManifest(
   }
 
   Object.entries(manifest.platforms).forEach(([key, platform]) => {
-    validatePlatform(key, platform);
+    validatePlatform(key, platform, releaseTag);
   });
 
   const matchedPlatforms = REQUIRED_PLATFORM_GROUPS.map(({ keys, label }) => {


### PR DESCRIPTION
## 变更

- 通过 `gh release view` 获取草稿 Release ID，再按 ID 读取资产元数据
- 将草稿的 `untagged-*` 临时下载路径改写为目标版本标签 URL
- 校验更新清单中的下载路径必须与当前版本标签一致
- 补充草稿 Release 路径转换与拒绝测试

## 根因

GitHub 按标签的 REST Release 端点无法读取草稿，返回 404；草稿资产的公开地址还包含临时 `untagged-*` 路径，不能直接写入正式更新清单。

## 验证

- `bun test`（122 项通过）
- `bun run build`
- Release YAML 解析通过
- 使用真实 `v0.1.5` 草稿的 15 个资产回放转换和清单校验