### PR TITLE
发布 0.1.6 并补充 ARM64 安装包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,22 @@ jobs:
           - name: Linux x64
             platform: ubuntu-22.04
             rustTargets: ""
-            args: --bundles appimage,deb
+            args: --bundles deb
+            appleSigningIdentity: ""
+          - name: Linux ARM64
+            platform: ubuntu-22.04-arm
+            rustTargets: aarch64-unknown-linux-gnu
+            args: --target aarch64-unknown-linux-gnu --bundles deb
             appleSigningIdentity: ""
           - name: Windows x64
             platform: windows-latest
             rustTargets: ""
             args: --bundles nsis,msi
+            appleSigningIdentity: ""
+          - name: Windows ARM64
+            platform: windows-11-arm
+            rustTargets: aarch64-pc-windows-msvc
+            args: --target aarch64-pc-windows-msvc --bundles nsis
             appleSigningIdentity: ""
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 本文件记录 FineShell 各版本的重要变更。版本号遵循[语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [0.1.6] - 2026-07-26
+
+### 工程
+
+- 增加 Linux ARM64 `.deb` 与 Windows ARM64 `.exe` 安装包构建。
+- Linux 发布包统一为 `.deb`，不再构建 AppImage。
+
 ## [0.1.5] - 2026-07-26
 
 ### 修复

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@
 前往 [GitHub Releases](https://github.com/Max0897/fineshell/releases) 下载对应平台的安装包：
 
 - macOS：Apple Silicon / Intel `.dmg`
-- Linux：x64 `.AppImage` / `.deb`
-- Windows：x64 `.exe`（NSIS）/ `.msi`
+- Linux：x64 / ARM64 `.deb`
+- Windows：x64 `.exe`（NSIS）/ `.msi`，ARM64 `.exe`（NSIS）
 
 ## 从源码运行
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fineshell",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/scripts/validate-updater-manifest.test.ts
+++ b/scripts/validate-updater-manifest.test.ts
@@ -17,17 +17,66 @@ describe("updater manifest validation", () => {
         manifest({
           "darwin-aarch64-app": platform,
           "darwin-x86_64": platform,
-          "linux-x86_64-appimage": platform,
+          "linux-x86_64-deb": platform,
+          "linux-aarch64-deb": platform,
           "windows-x86_64-nsis": platform,
+          "windows-aarch64-nsis": platform,
         }),
         "v1.2.3",
       ),
     ).toEqual([
       "darwin-aarch64-app",
       "darwin-x86_64",
-      "linux-x86_64-appimage",
+      "linux-x86_64-deb",
+      "linux-aarch64-deb",
       "windows-x86_64-nsis",
+      "windows-aarch64-nsis",
     ]);
+  });
+
+  test("rejects a manifest without ARM64 updater platforms", () => {
+    expect(() =>
+      validateUpdaterManifest(
+        manifest({
+          "darwin-aarch64": platform,
+          "darwin-x86_64": platform,
+          "linux-x86_64-deb": platform,
+          "windows-x86_64-nsis": platform,
+        }),
+        "v1.2.3",
+      ),
+    ).toThrow("缺少 Linux ARM64");
+  });
+
+  test("rejects AppImage-only Linux updater platforms", () => {
+    expect(() =>
+      validateUpdaterManifest(
+        manifest({
+          "darwin-aarch64": platform,
+          "darwin-x86_64": platform,
+          "linux-x86_64-appimage": platform,
+          "linux-aarch64-deb": platform,
+          "windows-x86_64-nsis": platform,
+          "windows-aarch64-nsis": platform,
+        }),
+        "v1.2.3",
+      ),
+    ).toThrow("缺少 Linux x64");
+  });
+
+  test("rejects a manifest without Windows ARM64", () => {
+    expect(() =>
+      validateUpdaterManifest(
+        manifest({
+          "darwin-aarch64": platform,
+          "darwin-x86_64": platform,
+          "linux-x86_64-deb": platform,
+          "linux-aarch64-deb": platform,
+          "windows-x86_64-nsis": platform,
+        }),
+        "v1.2.3",
+      ),
+    ).toThrow("缺少 Windows ARM64");
   });
 
   test("rejects a manifest without macOS updater platforms", () => {

--- a/scripts/validate-updater-manifest.ts
+++ b/scripts/validate-updater-manifest.ts
@@ -20,8 +20,12 @@ const REQUIRED_PLATFORM_GROUPS = [
     label: "macOS Intel",
   },
   {
-    keys: ["linux-x86_64-appimage", "linux-x86_64"],
+    keys: ["linux-x86_64-deb"],
     label: "Linux x64",
+  },
+  {
+    keys: ["linux-aarch64-deb"],
+    label: "Linux ARM64",
   },
   {
     keys: [
@@ -30,6 +34,10 @@ const REQUIRED_PLATFORM_GROUPS = [
       "windows-x86_64",
     ],
     label: "Windows x64",
+  },
+  {
+    keys: ["windows-aarch64-nsis", "windows-aarch64"],
+    label: "Windows ARM64",
   },
 ] as const;
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fineshell"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.22.1",
  "fast-socks5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fineshell"
-version = "0.1.5"
+version = "0.1.6"
 description = "A cross-platform SSH and SFTP client for terminal access, file management, and server monitoring."
 authors = ["Max"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FineShell",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.fineshell.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## 变更

- 新增 Linux ARM64 `.deb` 构建
- 新增 Windows ARM64 `.exe`（NSIS）构建
- 移除 Linux AppImage 构建
- 扩展更新清单跨架构校验
- 更新版本号、README 与 CHANGELOG

## 验证

- `bun run check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- Release 工作流 YAML 解析通过