### PR TITLE
修复主窗口自动检查更新权限

### DIFF
--- a/src-tauri/capabilities/updater.json
+++ b/src-tauri/capabilities/updater.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "updater",
-  "description": "Allow the settings window to check, install, and restart after signed updates",
-  "windows": ["settings"],
+  "description": "Allow the main and settings windows to check, install, and restart after signed updates",
+  "windows": ["main", "settings"],
   "permissions": ["updater:default", "process:allow-restart"]
 }

--- a/src/window-capabilities.test.ts
+++ b/src/window-capabilities.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import defaultCapability from "../src-tauri/capabilities/default.json";
+import updaterCapability from "../src-tauri/capabilities/updater.json";
 
 describe("window capabilities", () => {
   test("keeps auxiliary windows reusable", () => {
@@ -8,6 +9,15 @@ describe("window capabilities", () => {
     );
     expect(defaultCapability.permissions).not.toContain(
       "core:window:allow-destroy",
+    );
+  });
+
+  test("allows update checks from both application entry points", () => {
+    expect(updaterCapability.windows).toEqual(
+      expect.arrayContaining(["main", "settings"]),
+    );
+    expect(updaterCapability.permissions).toEqual(
+      expect.arrayContaining(["updater:default", "process:allow-restart"]),
     );
   });
 });


### PR DESCRIPTION
将 updater 与应用重启权限同时授权给 main 和 settings 窗口，修复主窗口启动检查在网络请求前被 Tauri capability 拒绝的问题。启动自动检查失败继续保持静默记录，设置页手动检查仍展示错误。\n\n验证：更新相关 7 项测试、前端生产构建和 cargo check 均通过。