### PR TITLE
新增粘贴托管 SSH 私钥功能

### DIFF
--- a/protocol/contract.json
+++ b/protocol/contract.json
@@ -14,6 +14,8 @@
     "delete_private_key_passphrase": true,
     "store_proxy_password": true,
     "delete_proxy_password": true,
+    "managed_ssh_key_import": true,
+    "managed_ssh_key_delete": true,
     "diagnostic_set_level": true,
     "diagnostic_record": true,
     "diagnostic_summary": true,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod credentials;
 mod diagnostics;
 mod dynamic_forward;
 mod external_edit;
+mod managed_keys;
 mod monitor;
 #[cfg(desktop)]
 mod native_menu;
@@ -27,6 +28,7 @@ pub fn run() {
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
 
     let builder = builder.setup(|app| {
+        managed_keys::initialize(app.handle()).map_err(std::io::Error::other)?;
         diagnostics::record_startup(app.handle());
         Ok(())
     });
@@ -56,6 +58,8 @@ pub fn run() {
             credentials::delete_private_key_passphrase,
             credentials::store_proxy_password,
             credentials::delete_proxy_password,
+            managed_keys::managed_ssh_key_import,
+            managed_keys::managed_ssh_key_delete,
             diagnostics::diagnostic_set_level,
             diagnostics::diagnostic_record,
             diagnostics::diagnostic_summary,

--- a/src-tauri/src/managed_keys.rs
+++ b/src-tauri/src/managed_keys.rs
@@ -1,0 +1,324 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+use crate::protocol::{CommandError, CommandResult};
+
+const MANAGED_KEY_PREFIX: &str = "managed://";
+const MAX_PRIVATE_KEY_BYTES: usize = 64 * 1024;
+const MANAGED_KEY_DIRECTORY: &str = "ssh-keys";
+
+static MANAGED_KEY_ROOT: OnceLock<PathBuf> = OnceLock::new();
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ManagedSshKeyImportResult {
+    reference: String,
+    key_type: String,
+}
+
+pub(crate) fn initialize(app: &AppHandle) -> Result<(), String> {
+    let root = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("无法定位应用数据目录：{error}"))?
+        .join(MANAGED_KEY_DIRECTORY);
+
+    if let Some(existing) = MANAGED_KEY_ROOT.get() {
+        if existing != &root {
+            return Err("托管密钥目录已经初始化为其他路径".to_string());
+        }
+        return Ok(());
+    }
+    MANAGED_KEY_ROOT
+        .set(root)
+        .map_err(|_| "无法初始化托管密钥目录".to_string())
+}
+
+#[tauri::command]
+pub(crate) fn managed_ssh_key_import(
+    key_id: String,
+    private_key: String,
+) -> CommandResult<ManagedSshKeyImportResult> {
+    let root = managed_key_root()
+        .map_err(|error| CommandError::from_message("managed_ssh_key_import", error))?;
+    import_private_key(root, &key_id, &private_key)
+        .map(|key_type| ManagedSshKeyImportResult {
+            reference: format!("{MANAGED_KEY_PREFIX}{key_id}"),
+            key_type,
+        })
+        .map_err(|error| CommandError::from_message("managed_ssh_key_import", error))
+}
+
+#[tauri::command]
+pub(crate) fn managed_ssh_key_delete(key_id: String) -> CommandResult<()> {
+    let root = managed_key_root()
+        .map_err(|error| CommandError::from_message("managed_ssh_key_delete", error))?;
+    delete_private_key(root, &key_id)
+        .map_err(|error| CommandError::from_message("managed_ssh_key_delete", error))
+}
+
+pub(crate) fn resolve_reference(reference: &str) -> Result<Option<PathBuf>, String> {
+    let Some(key_id) = reference.strip_prefix(MANAGED_KEY_PREFIX) else {
+        return Ok(None);
+    };
+    validate_key_id(key_id)?;
+    Ok(Some(key_path(managed_key_root()?, key_id)))
+}
+
+fn managed_key_root() -> Result<&'static Path, String> {
+    MANAGED_KEY_ROOT
+        .get()
+        .map(PathBuf::as_path)
+        .ok_or_else(|| "托管密钥目录尚未初始化".to_string())
+}
+
+fn validate_key_id(key_id: &str) -> Result<(), String> {
+    if key_id.is_empty()
+        || key_id.len() > 160
+        || !key_id
+            .bytes()
+            .all(|value| value.is_ascii_alphanumeric() || value == b'-' || value == b'_')
+    {
+        return Err("托管密钥标识无效".to_string());
+    }
+    Ok(())
+}
+
+fn key_path(root: &Path, key_id: &str) -> PathBuf {
+    root.join(format!("{key_id}.key"))
+}
+
+fn prepare_directory(root: &Path) -> Result<(), String> {
+    fs::create_dir_all(root).map_err(|error| format!("无法创建托管密钥目录：{error}"))?;
+    set_directory_permissions(root)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_directory_permissions(root: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(root, fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("无法设置托管密钥目录权限：{error}"))
+}
+
+#[cfg(not(unix))]
+fn set_directory_permissions(_root: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn validate_private_key(private_key: &str) -> Result<(String, &'static str), String> {
+    if private_key.len() > MAX_PRIVATE_KEY_BYTES {
+        return Err("SSH 私钥内容无效：超过 64 KB 限制".to_string());
+    }
+    if private_key.contains('\0') {
+        return Err("SSH 私钥内容无效".to_string());
+    }
+
+    let normalized_line_endings = private_key.replace("\r\n", "\n").replace('\r', "\n");
+    let trimmed = normalized_line_endings
+        .trim_start_matches('\u{feff}')
+        .trim();
+    if trimmed.is_empty() {
+        return Err("SSH 私钥内容不能为空".to_string());
+    }
+
+    const FORMATS: [(&str, &str, &str); 6] = [
+        (
+            "-----BEGIN OPENSSH PRIVATE KEY-----",
+            "-----END OPENSSH PRIVATE KEY-----",
+            "OpenSSH",
+        ),
+        (
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "-----END RSA PRIVATE KEY-----",
+            "RSA",
+        ),
+        (
+            "-----BEGIN EC PRIVATE KEY-----",
+            "-----END EC PRIVATE KEY-----",
+            "EC",
+        ),
+        (
+            "-----BEGIN DSA PRIVATE KEY-----",
+            "-----END DSA PRIVATE KEY-----",
+            "DSA",
+        ),
+        (
+            "-----BEGIN ENCRYPTED PRIVATE KEY-----",
+            "-----END ENCRYPTED PRIVATE KEY-----",
+            "PKCS#8（加密）",
+        ),
+        (
+            "-----BEGIN PRIVATE KEY-----",
+            "-----END PRIVATE KEY-----",
+            "PKCS#8",
+        ),
+    ];
+
+    for (header, footer, key_type) in FORMATS {
+        if !trimmed.starts_with(header) {
+            continue;
+        }
+        if !trimmed.ends_with(footer) {
+            return Err("SSH 私钥内容无效：头部和尾部不匹配".to_string());
+        }
+        let body = trimmed[header.len()..trimmed.len() - footer.len()].trim();
+        if body.is_empty() || body.contains("-----BEGIN ") || body.contains("-----END ") {
+            return Err("SSH 私钥内容无效".to_string());
+        }
+        return Ok((format!("{trimmed}\n"), key_type));
+    }
+
+    Err("SSH 私钥内容无效：无法识别格式，请粘贴完整的私钥".to_string())
+}
+
+fn import_private_key(root: &Path, key_id: &str, private_key: &str) -> Result<String, String> {
+    validate_key_id(key_id)?;
+    let (normalized, key_type) = validate_private_key(private_key)?;
+    prepare_directory(root)?;
+
+    let target = key_path(root, key_id);
+    if target.exists() {
+        return Err("同名托管密钥已经存在".to_string());
+    }
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temporary = root.join(format!(".{key_id}-{}-{unique}.tmp", std::process::id()));
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temporary)
+            .map_err(|error| format!("无法创建托管密钥临时文件：{error}"))?;
+        file.write_all(normalized.as_bytes())
+            .map_err(|error| format!("无法写入托管密钥：{error}"))?;
+        file.sync_all()
+            .map_err(|error| format!("无法同步托管密钥：{error}"))?;
+        drop(file);
+
+        if target.exists() {
+            return Err("同名托管密钥已经存在".to_string());
+        }
+        fs::hard_link(&temporary, &target).map_err(|error| format!("无法保存托管密钥：{error}"))?;
+        if let Err(error) = fs::remove_file(&temporary) {
+            let _ = fs::remove_file(&target);
+            return Err(format!("无法清理托管密钥临时文件：{error}"));
+        }
+        Ok(key_type.to_string())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn delete_private_key(root: &Path, key_id: &str) -> Result<(), String> {
+    validate_key_id(key_id)?;
+    match fs::remove_file(key_path(root, key_id)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("无法删除托管密钥：{error}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, time::SystemTime};
+
+    use super::{
+        delete_private_key, import_private_key, key_path, validate_key_id, validate_private_key,
+    };
+
+    const OPENSSH_KEY: &str = concat!(
+        "-----BEGIN OPENSSH PRIVATE KEY-----\r\n",
+        "b3BlbnNzaC1rZXktdjEAAAAA\r\n",
+        "-----END OPENSSH PRIVATE KEY-----"
+    );
+
+    fn temporary_directory(name: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "fineshell-managed-key-{name}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn accepts_supported_private_key_and_normalizes_line_endings() {
+        let (normalized, key_type) = validate_private_key(OPENSSH_KEY).unwrap();
+        assert_eq!(key_type, "OpenSSH");
+        assert!(!normalized.contains('\r'));
+        assert!(normalized.ends_with('\n'));
+    }
+
+    #[test]
+    fn rejects_public_keys_and_mismatched_pem_boundaries() {
+        assert!(validate_private_key("ssh-ed25519 AAAAC3Nza demo@example.com").is_err());
+        assert!(validate_private_key(concat!(
+            "-----BEGIN RSA PRIVATE KEY-----\n",
+            "AAAA\n",
+            "-----END PRIVATE KEY-----"
+        ))
+        .is_err());
+        assert!(validate_private_key(&"x".repeat(64 * 1024 + 1)).is_err());
+    }
+
+    #[test]
+    fn rejects_unsafe_key_identifiers() {
+        for key_id in ["", "../escape", "nested/key", "key.key", "密钥"] {
+            assert!(validate_key_id(key_id).is_err(), "accepted {key_id}");
+        }
+        assert!(validate_key_id("ssh-key_2026-07").is_ok());
+    }
+
+    #[test]
+    fn imports_with_restricted_permissions_and_deletes_idempotently() {
+        let root = temporary_directory("round-trip");
+        let key_id = "ssh-key-test";
+        assert_eq!(
+            import_private_key(&root, key_id, OPENSSH_KEY).unwrap(),
+            "OpenSSH"
+        );
+        let path = key_path(&root, key_id);
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            OPENSSH_KEY.replace("\r\n", "\n") + "\n"
+        );
+        assert!(import_private_key(&root, key_id, OPENSSH_KEY).is_err());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+
+        delete_private_key(&root, key_id).unwrap();
+        delete_private_key(&root, key_id).unwrap();
+        assert!(!path.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -399,14 +399,17 @@ fn validate_fingerprint(expected: Option<&str>, actual: &str) -> Result<(), Stri
     }
 }
 
-fn resolve_private_key_path(path: &str) -> PathBuf {
+fn resolve_private_key_path(path: &str) -> Result<PathBuf, String> {
+    if let Some(path) = crate::managed_keys::resolve_reference(path)? {
+        return Ok(path);
+    }
     let Some(relative) = path.strip_prefix("~/") else {
-        return PathBuf::from(path);
+        return Ok(PathBuf::from(path));
     };
-    std::env::var_os("HOME")
+    Ok(std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(|home| PathBuf::from(home).join(relative))
-        .unwrap_or_else(|| PathBuf::from(path))
+        .unwrap_or_else(|| PathBuf::from(path)))
 }
 
 fn configure_keepalive(session: &Session, interval_seconds: u32) {
@@ -676,8 +679,11 @@ fn authenticate_session(session: &Session, config: &SshAuthConfig) -> Result<(),
                 .map(str::trim)
                 .filter(|path| !path.is_empty())
                 .ok_or_else(|| "未配置 SSH 私钥文件".to_string())?;
-            let private_key = resolve_private_key_path(private_key_path);
+            let private_key = resolve_private_key_path(private_key_path)?;
             if !private_key.is_file() {
+                if private_key_path.starts_with("managed://") {
+                    return Err("托管 SSH 私钥不存在，请在设置中重新添加密钥".to_string());
+                }
                 return Err(format!("SSH 私钥文件不存在：{private_key_path}"));
             }
             let passphrase = credentials::get_private_key_passphrase(&config.host_id)?;

--- a/src/App.css
+++ b/src/App.css
@@ -2166,6 +2166,11 @@ body.sftp-remote-dragging * {
   white-space: nowrap;
 }
 
+.ssh-key-managed-content textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+}
+
 .proxy-form-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 150px;

--- a/src/components/SshKeySettings.tsx
+++ b/src/components/SshKeySettings.tsx
@@ -7,6 +7,7 @@ import {
   Message,
   Modal,
   Popconfirm,
+  Radio,
   Space,
   Table,
   Tooltip,
@@ -30,7 +31,12 @@ import {
   upsertSshKey,
 } from "../config-database";
 import { createCredentialReference } from "../credential-registry";
-import type { SshKeyFormValues, SshKeyRecord } from "../models";
+import type {
+  SshKeyFormValues,
+  SshKeyRecord,
+  SshKeySource,
+} from "../models";
+import { getSshKeySource } from "../ssh-keys";
 import {
   emitProtocolEventTo,
   listenProtocolEvent,
@@ -65,6 +71,26 @@ async function removePassphrase(sshKeyId: string) {
   await removeCredentialReference("privateKeyPassphrase", sshKeyId);
 }
 
+interface ManagedSshKeyImportResult {
+  reference: string;
+  keyType: string;
+}
+
+async function importManagedSshKey(sshKeyId: string, privateKey: string) {
+  if (!isTauri()) {
+    throw new Error("粘贴私钥仅在桌面应用中可用");
+  }
+  return invoke<ManagedSshKeyImportResult>("managed_ssh_key_import", {
+    keyId: sshKeyId,
+    privateKey,
+  });
+}
+
+async function deleteManagedSshKey(sshKeyId: string) {
+  if (!isTauri()) return;
+  await invoke("managed_ssh_key_delete", { keyId: sshKeyId });
+}
+
 interface SshKeyEditorModalProps {
   sshKey: SshKeyRecord | null;
   visible: boolean;
@@ -79,6 +105,8 @@ function SshKeyEditorModal({
   onSubmit,
 }: SshKeyEditorModalProps) {
   const [form] = Form.useForm<SshKeyFormValues>();
+  const initialSource = sshKey ? getSshKeySource(sshKey) : "file";
+  const [source, setSource] = useState<SshKeySource>(initialSource);
 
   return (
     <Modal
@@ -86,7 +114,7 @@ function SshKeyEditorModal({
       footer={null}
       maskClosable={false}
       onCancel={onCancel}
-      style={{ width: 560 }}
+      style={{ width: 620 }}
       title={sshKey ? "编辑密钥" : "新增密钥"}
       visible={visible}
     >
@@ -94,7 +122,9 @@ function SshKeyEditorModal({
         form={form}
         initialValues={{
           name: sshKey?.name ?? "",
+          source: initialSource,
           privateKeyPath: sshKey?.privateKeyPath ?? "",
+          privateKeyContent: "",
           passphrase: "",
         }}
         layout="vertical"
@@ -107,25 +137,57 @@ function SshKeyEditorModal({
         >
           <Input autoFocus placeholder="例如：生产环境 Ed25519" />
         </Form.Item>
-        <Form.Item
-          field="privateKeyPath"
-          label="私钥文件"
-          rules={[{ required: true, message: "请选择私钥文件" }]}
-        >
-          <Input.Search
-            onSearch={() =>
-              void choosePrivateKeyPath().then((path) => {
-                if (path) form.setFieldValue("privateKeyPath", path);
-              })
-            }
-            placeholder="选择或输入私钥文件路径"
-            searchButton={
-              <Tooltip content="选择私钥文件">
-                <IconFolder />
-              </Tooltip>
-            }
+        <Form.Item field="source" label="添加方式">
+          <Radio.Group
+            disabled={Boolean(sshKey)}
+            onChange={(value) => setSource(value as SshKeySource)}
+            options={[
+              { label: "选择文件", value: "file" },
+              { label: "粘贴私钥", value: "managed" },
+            ]}
+            type="button"
           />
         </Form.Item>
+        {source === "file" ? (
+          <Form.Item
+            field="privateKeyPath"
+            label="私钥文件"
+            rules={[{ required: true, message: "请选择私钥文件" }]}
+          >
+            <Input.Search
+              onSearch={() =>
+                void choosePrivateKeyPath().then((path) => {
+                  if (path) form.setFieldValue("privateKeyPath", path);
+                })
+              }
+              placeholder="选择或输入私钥文件路径"
+              searchButton={
+                <Tooltip content="选择私钥文件">
+                  <IconFolder />
+                </Tooltip>
+              }
+            />
+          </Form.Item>
+        ) : sshKey ? (
+          <Form.Item label="私钥">
+            <Input disabled value="FineShell 托管密钥" />
+          </Form.Item>
+        ) : (
+          <Form.Item
+            className="ssh-key-managed-content"
+            field="privateKeyContent"
+            label="私钥内容"
+            rules={[{ required: true, message: "请粘贴完整的私钥内容" }]}
+          >
+            <Input.TextArea
+              autoSize={{ minRows: 7, maxRows: 11 }}
+              placeholder={
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----"
+              }
+              spellCheck={false}
+            />
+          </Form.Item>
+        )}
         <Form.Item field="passphrase" label="私钥口令">
           <Input.Password
             placeholder={sshKey ? "留空则保留原口令" : "没有口令可留空"}
@@ -221,14 +283,31 @@ function SshKeySettings() {
 
   const saveSshKey = async (values: SshKeyFormValues) => {
     const sshKeyId = editingSshKey?.id ?? createSshKeyId();
-    const sshKey: SshKeyRecord = {
-      id: sshKeyId,
-      name: values.name.trim(),
-      privateKeyPath: values.privateKeyPath.trim(),
-    };
     setActing(true);
     let passphraseStored = false;
+    let managedKeyImported = false;
     try {
+      const existingSource = editingSshKey
+        ? getSshKeySource(editingSshKey)
+        : values.source;
+      let privateKeyPath = values.privateKeyPath?.trim() ?? "";
+      if (!editingSshKey && existingSource === "managed") {
+        const result = await importManagedSshKey(
+          sshKeyId,
+          values.privateKeyContent?.trim() ?? "",
+        );
+        privateKeyPath = result.reference;
+        managedKeyImported = true;
+      } else if (editingSshKey && existingSource === "managed") {
+        privateKeyPath = editingSshKey.privateKeyPath;
+      }
+
+      const sshKey: SshKeyRecord = {
+        id: sshKeyId,
+        name: values.name.trim(),
+        privateKeyPath,
+        ...(existingSource === "managed" ? { source: "managed" as const } : {}),
+      };
       if (values.passphrase) {
         await storePassphrase(sshKeyId, values.passphrase);
         passphraseStored = true;
@@ -246,13 +325,16 @@ function SshKeySettings() {
           Message.warning("密钥已保存，但凭据索引更新失败，可重新扫描");
         });
       }
-      await notifyMainWindow();
+      await notifyMainWindow().catch(() => undefined);
       setEditorVisible(false);
       setEditingSshKey(null);
       Message.success(editingSshKey ? "密钥已更新" : "密钥已添加");
     } catch (error) {
       if (!editingSshKey && passphraseStored) {
         await removePassphrase(sshKeyId).catch(() => undefined);
+      }
+      if (managedKeyImported) {
+        await deleteManagedSshKey(sshKeyId).catch(() => undefined);
       }
       Message.error(String(error));
     } finally {
@@ -265,12 +347,20 @@ function SshKeySettings() {
     try {
       const configuration = await deleteSshKey(sshKey.id);
       setSshKeys(configuration.sshKeys);
-      await notifyMainWindow();
-      try {
-        await removePassphrase(sshKey.id);
+      await notifyMainWindow().catch(() => undefined);
+      const cleanupFailures: string[] = [];
+      await removePassphrase(sshKey.id).catch(() => {
+        cleanupFailures.push("系统凭据");
+      });
+      if (getSshKeySource(sshKey) === "managed") {
+        await deleteManagedSshKey(sshKey.id).catch(() => {
+          cleanupFailures.push("托管私钥文件");
+        });
+      }
+      if (cleanupFailures.length === 0) {
         Message.success(`已删除 ${sshKey.name}`);
-      } catch {
-        Message.warning("密钥已删除，但系统凭据清理失败");
+      } else {
+        Message.warning(`密钥记录已删除，但${cleanupFailures.join("和")}清理失败`);
       }
     } catch (error) {
       Message.error(String(error));
@@ -288,7 +378,9 @@ function SshKeySettings() {
           <div className="ssh-key-name-cell">
             <Typography.Text bold>{sshKey.name}</Typography.Text>
             <Typography.Text type="secondary">
-              {sshKey.privateKeyPath}
+              {getSshKeySource(sshKey) === "managed"
+                ? "FineShell 托管"
+                : sshKey.privateKeyPath}
             </Typography.Text>
           </div>
         ),

--- a/src/config-database.test.ts
+++ b/src/config-database.test.ts
@@ -419,4 +419,36 @@ describe("configuration import and export", () => {
     });
     expect(imported.sshKeys[0]).not.toHaveProperty("passphrase");
   });
+
+  test("preserves FineShell-managed key references without exporting key contents", () => {
+    const contents = serializeConfigurationExport(
+      {
+        ...migrateLegacyConfiguration(
+          null,
+          null,
+          "2026-07-27T00:00:00.000Z",
+        ),
+        sshKeys: [
+          {
+            id: "ssh-key-managed",
+            name: "Managed key",
+            privateKeyPath: "managed://ssh-key-managed",
+            source: "managed",
+            privateKeyContent: "must-not-be-exported",
+          } as never,
+        ],
+      },
+      "2026-07-27T00:00:00.000Z",
+    );
+
+    expect(contents).not.toContain("must-not-be-exported");
+    expect(parseConfigurationExport(contents).sshKeys).toEqual([
+      {
+        id: "ssh-key-managed",
+        name: "Managed key",
+        privateKeyPath: "managed://ssh-key-managed",
+        source: "managed",
+      },
+    ]);
+  });
 });

--- a/src/config-database.ts
+++ b/src/config-database.ts
@@ -26,6 +26,10 @@ import {
   upsertKnownHostRecord,
 } from "./known-hosts";
 import { normalizeRemoteDirectoryPath } from "./sftp-utils";
+import {
+  getSshKeySource,
+  managedSshKeyReference,
+} from "./ssh-keys";
 import { applyConnectionHistoryPolicy } from "./connection-history";
 import {
   sanitizeCredentialReference,
@@ -165,10 +169,27 @@ function sanitizeSshKey(value: unknown): SshKeyRecord | undefined {
   const privateKeyPath = stringValue(value.privateKeyPath);
   if (!id || !name || !privateKeyPath) return undefined;
 
+  const normalizedId = id.trim();
+  const normalizedName = name.trim();
+  const normalizedPath = privateKeyPath.trim();
+  if (!normalizedId || !normalizedName || !normalizedPath) return undefined;
+  const source = getSshKeySource({
+    privateKeyPath: normalizedPath,
+    source: value.source === "managed" ? "managed" : undefined,
+  });
+  if (
+    source === "managed" &&
+    (normalizedPath !== managedSshKeyReference(normalizedId) ||
+      !/^[A-Za-z0-9_-]{1,160}$/.test(normalizedId))
+  ) {
+    return undefined;
+  }
+
   return {
-    id,
-    name: name.trim(),
-    privateKeyPath: privateKeyPath.trim(),
+    id: normalizedId,
+    name: normalizedName,
+    privateKeyPath: normalizedPath,
+    ...(source === "managed" ? { source } : {}),
   };
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -21,13 +21,20 @@ export interface ProxyFormValues extends Omit<ProxyRecord, "id"> {
   password?: string;
 }
 
+export type SshKeySource = "file" | "managed";
+
 export interface SshKeyRecord {
   id: string;
   name: string;
   privateKeyPath: string;
+  source?: SshKeySource;
 }
 
-export interface SshKeyFormValues extends Omit<SshKeyRecord, "id"> {
+export interface SshKeyFormValues {
+  name: string;
+  source: SshKeySource;
+  privateKeyPath?: string;
+  privateKeyContent?: string;
   passphrase?: string;
 }
 

--- a/src/ssh-keys.ts
+++ b/src/ssh-keys.ts
@@ -1,0 +1,16 @@
+import type { SshKeyRecord, SshKeySource } from "./models";
+
+export const MANAGED_SSH_KEY_PREFIX = "managed://";
+
+export function getSshKeySource(
+  sshKey: Pick<SshKeyRecord, "source" | "privateKeyPath">,
+): SshKeySource {
+  return sshKey.source === "managed" ||
+    sshKey.privateKeyPath.startsWith(MANAGED_SSH_KEY_PREFIX)
+    ? "managed"
+    : "file";
+}
+
+export function managedSshKeyReference(sshKeyId: string) {
+  return `${MANAGED_SSH_KEY_PREFIX}${sshKeyId}`;
+}

--- a/src/tauri-protocol.test.ts
+++ b/src/tauri-protocol.test.ts
@@ -16,7 +16,7 @@ describe("Tauri shared protocol", () => {
     expect(PROTOCOL_VERSION).toBe(contract.version);
     expect(contract.commands[command]).toBe(true);
     expect(contract.events[event]).toBe(true);
-    expect(Object.keys(contract.commands)).toHaveLength(60);
+    expect(Object.keys(contract.commands)).toHaveLength(62);
     expect(Object.keys(contract.events)).toHaveLength(8);
   });
 


### PR DESCRIPTION
## 变更内容

- 密钥管理支持选择文件和粘贴私钥两种添加方式
- 粘贴的私钥由 Rust 校验后保存到应用数据目录，配置仅保留托管引用
- 终端、SFTP 和跳板机统一解析托管密钥
- 删除密钥时同步清理托管文件和系统凭据
- 保持已有文件路径密钥与旧配置兼容

## 安全性

- 限制私钥大小并校验支持的 PEM/OpenSSH 格式
- Unix 平台使用 0700 目录权限和 0600 文件权限
- 拒绝路径穿越标识，保存失败时清理临时文件和已写入口令

## 验证

- `bun test`：129 项通过
- `bun run build`：通过
- `cargo test --lib`：65 项通过，8 项在线环境测试按配置忽略
- `cargo clippy --all-targets -- -D warnings`：通过