### PR TITLE
完善 Shell Integration 与 SFTP 上传体验

### DIFF
--- a/protocol/contract.json
+++ b/protocol/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": 10,
+  "version": 11,
   "commands": {
     "protocol_version": true,
     "open_settings_window": true,
@@ -48,6 +48,7 @@
     "sftp_list": true,
     "sftp_inspect_upload_paths": true,
     "sftp_create_directory": true,
+    "sftp_ensure_upload_directories": true,
     "sftp_create_file": true,
     "sftp_rename": true,
     "sftp_copy": true,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             sftp::sftp_list,
             sftp::sftp_inspect_upload_paths,
             sftp::sftp_create_directory,
+            sftp::sftp_ensure_upload_directories,
             sftp::sftp_create_file,
             sftp::sftp_rename,
             sftp::sftp_copy,

--- a/src-tauri/src/protocol.rs
+++ b/src-tauri/src/protocol.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-pub(crate) const PROTOCOL_VERSION: u16 = 10;
+pub(crate) const PROTOCOL_VERSION: u16 = 11;
 
 pub(crate) const SSH_OUTPUT_EVENT: &str = "ssh-output";
 pub(crate) const SSH_STATUS_EVENT: &str = "ssh-status";

--- a/src-tauri/src/sftp.rs
+++ b/src-tauri/src/sftp.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ffi::OsString,
     fs::{self, File as LocalFile, OpenOptions},
     io::{Read, Write},
@@ -109,8 +109,16 @@ pub(crate) struct AiSftpFileOperationResult {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LocalUploadFile {
     path: String,
-    name: String,
+    relative_path: String,
     size: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LocalUploadInspection {
+    files: Vec<LocalUploadFile>,
+    directories: Vec<String>,
+    skipped_paths: usize,
 }
 
 #[derive(Clone, Copy, Deserialize)]
@@ -141,6 +149,11 @@ enum SftpCommand {
     },
     CreateDirectory {
         path: String,
+        reply: Sender<Result<(), String>>,
+    },
+    EnsureUploadDirectories {
+        base_path: String,
+        relative_paths: Vec<String>,
         reply: Sender<Result<(), String>>,
     },
     CreateFile {
@@ -599,25 +612,155 @@ fn remote_exists(sftp: &Sftp, path: &Path) -> bool {
     sftp.lstat(path).is_ok()
 }
 
-fn inspect_upload_paths(paths: Vec<String>) -> Result<Vec<LocalUploadFile>, String> {
+fn local_upload_relative_path(path: &Path) -> Option<String> {
+    let mut segments = Vec::new();
+    for component in path.components() {
+        let std::path::Component::Normal(segment) = component else {
+            return None;
+        };
+        segments.push(segment.to_str()?.to_string());
+    }
+    (!segments.is_empty()).then(|| segments.join("/"))
+}
+
+fn inspect_upload_directory(
+    directory: &Path,
+    relative_directory: &Path,
+    inspection: &mut LocalUploadInspection,
+) {
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(_) => {
+            inspection.skipped_paths += 1;
+            return;
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => {
+                inspection.skipped_paths += 1;
+                continue;
+            }
+        };
+        let metadata = match entry.path().symlink_metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                inspection.skipped_paths += 1;
+                continue;
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            inspection.skipped_paths += 1;
+            continue;
+        }
+        let relative_path = relative_directory.join(entry.file_name());
+        let Some(relative_path_text) = local_upload_relative_path(&relative_path) else {
+            inspection.skipped_paths += 1;
+            continue;
+        };
+        if metadata.is_dir() {
+            inspection.directories.push(relative_path_text);
+            inspect_upload_directory(&entry.path(), &relative_path, inspection);
+        } else if metadata.is_file() {
+            inspection.files.push(LocalUploadFile {
+                path: entry.path().to_string_lossy().into_owned(),
+                relative_path: relative_path_text,
+                size: metadata.len(),
+            });
+        } else {
+            inspection.skipped_paths += 1;
+        }
+    }
+}
+
+fn inspect_upload_paths(paths: Vec<String>) -> Result<LocalUploadInspection, String> {
     if paths.is_empty() {
         return Err("没有选择需要上传的文件".to_string());
     }
-    Ok(paths
-        .into_iter()
-        .filter_map(|path| {
-            let local_path = Path::new(&path);
-            let metadata = local_path.metadata().ok()?;
-            if !metadata.is_file() {
-                return None;
+    let mut inspection = LocalUploadInspection {
+        files: Vec::new(),
+        directories: Vec::new(),
+        skipped_paths: 0,
+    };
+    let mut root_names = HashSet::new();
+    for path in paths {
+        let local_path = Path::new(&path);
+        let metadata = match local_path.symlink_metadata() {
+            Ok(metadata) if !metadata.file_type().is_symlink() => metadata,
+            _ => {
+                inspection.skipped_paths += 1;
+                continue;
             }
-            Some(LocalUploadFile {
-                name: local_path.file_name()?.to_string_lossy().into_owned(),
+        };
+        let Some(root_name) = local_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+        else {
+            inspection.skipped_paths += 1;
+            continue;
+        };
+        if !root_names.insert(root_name.clone()) {
+            inspection.skipped_paths += 1;
+            continue;
+        }
+        let root_relative = PathBuf::from(&root_name);
+        if metadata.is_dir() {
+            inspection.directories.push(root_name);
+            inspect_upload_directory(local_path, &root_relative, &mut inspection);
+        } else if metadata.is_file() {
+            inspection.files.push(LocalUploadFile {
                 path,
+                relative_path: root_name,
                 size: metadata.len(),
-            })
-        })
-        .collect())
+            });
+        } else {
+            inspection.skipped_paths += 1;
+        }
+    }
+    inspection.directories.sort_by(|left, right| {
+        left.matches('/')
+            .count()
+            .cmp(&right.matches('/').count())
+            .then_with(|| left.cmp(right))
+    });
+    inspection.files.sort_by(|left, right| {
+        left.relative_path
+            .to_lowercase()
+            .cmp(&right.relative_path.to_lowercase())
+    });
+    Ok(inspection)
+}
+
+fn ensure_upload_directories(
+    sftp: &Sftp,
+    base_path: &str,
+    relative_paths: &[String],
+) -> Result<(), String> {
+    let base_path = normalize_remote_operation_path(base_path)?;
+    let mut ensured = HashSet::new();
+    for relative_path in relative_paths {
+        let mut current = PathBuf::from(&base_path);
+        for segment in relative_path.split('/') {
+            if segment.is_empty() || matches!(segment, "." | "..") || segment.contains('\0') {
+                return Err("本地目录包含无法上传的路径".to_string());
+            }
+            current.push(segment);
+            let current_text = remote_path_text(&current);
+            if !ensured.insert(current_text.clone()) {
+                continue;
+            }
+            match sftp.lstat(&current) {
+                Ok(stat) if stat.is_dir() => {}
+                Ok(_) => return Err(format!("远程目标已存在同名文件：{current_text}")),
+                Err(_) => sftp
+                    .mkdir(&current, 0o755)
+                    .map_err(|error| format!("无法创建远程目录 {current_text}：{error}"))?,
+            }
+        }
+    }
+    Ok(())
 }
 
 fn create_empty_file(sftp: &Sftp, path: &str) -> Result<(), String> {
@@ -2137,6 +2280,17 @@ fn run_session(
                     .map_err(|error| format!("新建远程目录失败：{error}"));
                 let _ = reply.send(result);
             }
+            SftpCommand::EnsureUploadDirectories {
+                base_path,
+                relative_paths,
+                reply,
+            } => {
+                let _ = reply.send(ensure_upload_directories(
+                    &sftp,
+                    &base_path,
+                    &relative_paths,
+                ));
+            }
             SftpCommand::CreateFile { path, reply } => {
                 let _ = reply.send(create_empty_file(&sftp, &path));
             }
@@ -2419,10 +2573,12 @@ pub(crate) async fn sftp_list(
 }
 
 #[tauri::command]
-pub(crate) fn sftp_inspect_upload_paths(
+pub(crate) async fn sftp_inspect_upload_paths(
     paths: Vec<String>,
-) -> Result<Vec<LocalUploadFile>, String> {
-    inspect_upload_paths(paths)
+) -> Result<LocalUploadInspection, String> {
+    tauri::async_runtime::spawn_blocking(move || inspect_upload_paths(paths))
+        .await
+        .map_err(|error| format!("扫描本地上传目录任务异常结束：{error}"))?
 }
 
 #[tauri::command]
@@ -2433,6 +2589,23 @@ pub(crate) async fn sftp_create_directory(
 ) -> Result<(), String> {
     dispatch(manager.inner().clone(), session_id, move |reply| {
         SftpCommand::CreateDirectory { path, reply }
+    })
+    .await
+}
+
+#[tauri::command]
+pub(crate) async fn sftp_ensure_upload_directories(
+    manager: State<'_, SftpSessionManager>,
+    session_id: String,
+    base_path: String,
+    relative_paths: Vec<String>,
+) -> Result<(), String> {
+    dispatch(manager.inner().clone(), session_id, move |reply| {
+        SftpCommand::EnsureUploadDirectories {
+            base_path,
+            relative_paths,
+            reply,
+        }
     })
     .await
 }
@@ -3080,7 +3253,7 @@ mod tests {
     }
 
     #[test]
-    fn keeps_only_regular_files_for_batch_uploads() {
+    fn inspects_files_directories_and_empty_directories_for_batch_uploads() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -3092,18 +3265,55 @@ mod tests {
         fs::create_dir(&directory).unwrap();
         let file = directory.join("report.txt");
         fs::write(&file, b"report").unwrap();
+        let folder = directory.join("assets");
+        let empty_folder = folder.join("empty");
+        fs::create_dir_all(&empty_folder).unwrap();
+        fs::write(folder.join("logo.txt"), b"logo").unwrap();
 
         let inspected = inspect_upload_paths(vec![
             file.to_string_lossy().into_owned(),
-            directory.to_string_lossy().into_owned(),
+            folder.to_string_lossy().into_owned(),
             directory.join("missing.txt").to_string_lossy().into_owned(),
         ])
         .unwrap();
 
-        assert_eq!(inspected.len(), 1);
-        assert_eq!(inspected[0].name, "report.txt");
-        assert_eq!(inspected[0].size, 6);
+        assert_eq!(inspected.skipped_paths, 1);
+        assert_eq!(inspected.directories, vec!["assets", "assets/empty"]);
+        assert_eq!(inspected.files.len(), 2);
+        assert_eq!(inspected.files[0].relative_path, "assets/logo.txt");
+        assert_eq!(inspected.files[0].size, 4);
+        assert_eq!(inspected.files[1].relative_path, "report.txt");
+        assert_eq!(inspected.files[1].size, 6);
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn skips_duplicate_upload_roots() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "fineshell-upload-duplicates-{}-{unique}",
+            std::process::id()
+        ));
+        let first = root.join("first");
+        let second = root.join("second");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+        fs::write(first.join("same.txt"), b"first").unwrap();
+        fs::write(second.join("same.txt"), b"second").unwrap();
+
+        let inspected = inspect_upload_paths(vec![
+            first.join("same.txt").to_string_lossy().into_owned(),
+            second.join("same.txt").to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        assert_eq!(inspected.files.len(), 1);
+        assert_eq!(inspected.files[0].relative_path, "same.txt");
+        assert_eq!(inspected.skipped_paths, 1);
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "width": 1280,
         "height": 820,
         "minWidth": 720,
-        "minHeight": 520
+        "minHeight": 520,
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -8,7 +8,8 @@
         "width": 1280,
         "height": 820,
         "minWidth": 720,
-        "minHeight": 520
+        "minHeight": 520,
+        "dragDropEnabled": true
       },
       {
         "label": "settings",

--- a/src/App.css
+++ b/src/App.css
@@ -2325,6 +2325,10 @@ body.ai-sidebar-resizing::after {
   overflow-wrap: anywhere;
 }
 
+.quick-command-parameter-modal .modal-actions {
+  margin-top: 16px;
+}
+
 @container (max-width: 360px) {
   .terminal-search-result {
     display: none;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,6 +285,9 @@ function App() {
   const [sftpCurrentPaths, setSftpCurrentPaths] = useState<
     Record<string, string>
   >({});
+  const [terminalCurrentDirectories, setTerminalCurrentDirectories] = useState<
+    Record<string, { path: string; revision: number }>
+  >({});
   const [aiRemoteFileContexts, setAiRemoteFileContexts] = useState<
     Record<string, AiRemoteFileContext[]>
   >({});
@@ -377,6 +380,27 @@ function App() {
         return current[sessionId] === path
           ? current
           : { ...current, [sessionId]: path };
+      });
+    },
+    [],
+  );
+
+  const updateTerminalCurrentDirectory = useCallback(
+    (sessionId: string, path: string) => {
+      setTerminalCurrentDirectories((current) => {
+        if (!path) {
+          if (!(sessionId in current)) return current;
+          const next = { ...current };
+          delete next[sessionId];
+          return next;
+        }
+        return {
+          ...current,
+          [sessionId]: {
+            path,
+            revision: (current[sessionId]?.revision ?? 0) + 1,
+          },
+        };
       });
     },
     [],
@@ -1229,6 +1253,13 @@ function App() {
         ),
       ),
     );
+    setTerminalCurrentDirectories((currentDirectories) =>
+      Object.fromEntries(
+        Object.entries(currentDirectories).filter(
+          ([sessionId]) => !closingIds.has(sessionId),
+        ),
+      ),
+    );
     setAiBusinessContexts((currentContexts) =>
       Object.fromEntries(
         Object.entries(currentContexts).filter(
@@ -1366,6 +1397,7 @@ function App() {
               openAiAssistant("请解释这段终端输出，并给出排查建议。");
             }}
             onCommandLifecycle={setTerminalCommandSubmission}
+            onCurrentDirectoryChange={updateTerminalCurrentDirectory}
             onRecentOutputChange={(output) =>
               setTerminalRecentOutputs((current) => {
                 const next = output.slice(-settings.aiContextMaxChars);
@@ -1438,6 +1470,11 @@ function App() {
       }
       session={activeSession}
       showHiddenFiles={settings.showHiddenFiles}
+      terminalDirectory={
+        activeSessionId
+          ? terminalCurrentDirectories[activeSessionId]
+          : undefined
+      }
     />
   );
 

--- a/src/app-settings.test.ts
+++ b/src/app-settings.test.ts
@@ -46,7 +46,6 @@ describe("app settings", () => {
       aiFileProposalsEnabled: false,
       aiCommandProposalsEnabled: false,
       aiCommandTrackingEnabled: false,
-      aiShellIntegrationEnabled: true,
     });
 
     expect(settings).toMatchObject({
@@ -79,7 +78,6 @@ describe("app settings", () => {
       aiFileProposalsEnabled: false,
       aiCommandProposalsEnabled: false,
       aiCommandTrackingEnabled: false,
-      aiShellIntegrationEnabled: true,
     });
   });
 

--- a/src/app-settings.ts
+++ b/src/app-settings.ts
@@ -46,7 +46,6 @@ export interface AppSettings {
   aiFileProposalsEnabled: boolean;
   aiCommandProposalsEnabled: boolean;
   aiCommandTrackingEnabled: boolean;
-  aiShellIntegrationEnabled: boolean;
 }
 
 export const DEFAULT_APP_SETTINGS: AppSettings = {
@@ -79,7 +78,6 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   aiFileProposalsEnabled: true,
   aiCommandProposalsEnabled: true,
   aiCommandTrackingEnabled: true,
-  aiShellIntegrationEnabled: false,
 };
 
 export const TERMINAL_FONT_FAMILIES: Record<TerminalFontFamily, string> = {
@@ -267,10 +265,6 @@ export function sanitizeAppSettings(value: unknown): AppSettings {
     aiCommandTrackingEnabled: booleanValue(
       settings.aiCommandTrackingEnabled,
       DEFAULT_APP_SETTINGS.aiCommandTrackingEnabled,
-    ),
-    aiShellIntegrationEnabled: booleanValue(
-      settings.aiShellIntegrationEnabled,
-      DEFAULT_APP_SETTINGS.aiShellIntegrationEnabled,
     ),
   };
 }

--- a/src/components/AiComposer.tsx
+++ b/src/components/AiComposer.tsx
@@ -233,7 +233,11 @@ function AiComposer({
             </span>
           </Tooltip>
           {sending ? (
-            <Button icon={<IconStop />} onClick={() => void onCancel()}>
+            <Button
+              icon={<IconStop />}
+              onClick={() => void onCancel()}
+              size="small"
+            >
               停止
             </Button>
           ) : (
@@ -241,6 +245,7 @@ function AiComposer({
               disabled={!sendEnabled}
               icon={<IconSend />}
               onClick={onSend}
+              size="small"
               type="primary"
             >
               发送

--- a/src/components/AiSettings.tsx
+++ b/src/components/AiSettings.tsx
@@ -468,28 +468,6 @@ function AiSettings({
       </div>
       <div className="settings-row">
         <span className="settings-label-with-description">
-          <Typography.Text>Shell Integration</Typography.Text>
-          <Typography.Text type="secondary">
-            在当前 Bash/Zsh
-            会话中临时获取命令结束边界与退出码，不修改远端配置文件
-          </Typography.Text>
-        </span>
-        <div className="settings-control">
-          <Switch
-            aria-label="启用 Shell Integration"
-            checked={settings.aiShellIntegrationEnabled}
-            disabled={
-              !settings.aiCommandProposalsEnabled ||
-              !settings.aiCommandTrackingEnabled
-            }
-            onChange={(checked) =>
-              updateSetting("aiShellIntegrationEnabled", checked)
-            }
-          />
-        </div>
-      </div>
-      <div className="settings-row">
-        <span className="settings-label-with-description">
           <Typography.Text>服务能力</Typography.Text>
           <Typography.Text type="secondary">
             会发起少量测试请求，不执行服务器操作

--- a/src/components/HostEditorModal.tsx
+++ b/src/components/HostEditorModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Button,
   Form,
@@ -20,6 +20,7 @@ import type {
 } from "../models";
 import type { AppSettings } from "../app-settings";
 import { recordDiagnostic } from "../diagnostics";
+import { collectHostGroupPaths } from "../host-organization";
 import PortForwardRulesEditor from "./PortForwardRulesEditor";
 
 type ConnectionDefaults = Pick<
@@ -82,6 +83,14 @@ function HostEditorModal({
   const [dynamicPortForwards, setDynamicPortForwards] = useState(
     host?.dynamicPortForwards ?? [],
   );
+  const groupOptions = useMemo(
+    () =>
+      collectHostGroupPaths(hosts).map((group) => ({
+        label: group,
+        value: group,
+      })),
+    [hosts],
+  );
 
   useEffect(() => {
     if (visible) {
@@ -120,7 +129,7 @@ function HostEditorModal({
         privateKeyPath: "",
         privateKeyPassphrase: "",
         password: "",
-        group: "",
+        group: undefined,
         proxyId: undefined,
         jumpHostId: undefined,
       };
@@ -205,7 +214,20 @@ function HostEditorModal({
                   <Input autoFocus placeholder="例如：生产服务器" />
                 </Form.Item>
                 <Form.Item field="group" label="分组">
-                  <Input placeholder="可选" />
+                  <Select
+                    allowClear
+                    allowCreate={{
+                      formatter: (inputValue, creating) => ({
+                        label: creating
+                          ? `新建分组“${inputValue}”`
+                          : inputValue,
+                        value: inputValue,
+                      }),
+                    }}
+                    options={groupOptions}
+                    placeholder="选择或输入分组"
+                    showSearch
+                  />
                 </Form.Item>
               </div>
               <div className="host-form-row">

--- a/src/components/SftpPanel.tsx
+++ b/src/components/SftpPanel.tsx
@@ -22,11 +22,11 @@ import {
 import type { TableColumnProps } from "@arco-design/web-react";
 import { isTauri } from "@tauri-apps/api/core";
 import { join } from "@tauri-apps/api/path";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { diagnosticInvoke as invoke, recordDiagnostic } from "../diagnostics";
+import { isApplePlatform } from "../platform-utils";
 import {
   IconApps,
   IconArchive,
@@ -100,6 +100,7 @@ import {
   remoteArchiveFormatFromName,
   remoteJoinPath,
   remoteParentPath,
+  resolveNativeDropPoint,
   selectAllSftpEntryKeys,
   setRemotePathBookmark,
 } from "../sftp-utils";
@@ -174,8 +175,14 @@ type TransferRecord = TransferActivityRecord;
 
 interface LocalUploadFile {
   path: string;
-  name: string;
+  relativePath: string;
   size: number;
+}
+
+interface LocalUploadInspection {
+  files: LocalUploadFile[];
+  directories: string[];
+  skippedPaths: number;
 }
 
 interface RemoteTextFile {
@@ -330,6 +337,7 @@ function SftpPanel({
   const [pasteConflictPolicy, setPasteConflictPolicy] =
     useState<PasteConflictPolicy>("rename");
   const [fileDropActive, setFileDropActive] = useState(false);
+  const [fileDropTargetPath, setFileDropTargetPath] = useState<string>();
   const [sftpLocations, setSftpLocations] = useState<
     Record<string, SftpLocationRecord>
   >({});
@@ -357,9 +365,9 @@ function SftpPanel({
   const sftpLocationsRef = useRef(sftpLocations);
   const locationPersistenceErrorRef = useRef(false);
   const readyRef = useRef(false);
-  const queueUploadPathsRef = useRef<(paths: string[]) => Promise<void>>(
-    async () => undefined,
-  );
+  const queueUploadPathsRef = useRef<
+    (paths: string[], targetDirectory?: string) => Promise<void>
+  >(async () => undefined);
 
   useEffect(() => {
     browsersRef.current = browsers;
@@ -1194,64 +1202,106 @@ function SftpPanel({
     });
   }
 
-  async function queueUploadPaths(paths: string[]) {
+  async function queueUploadPaths(paths: string[], targetDirectory?: string) {
     if (!session || !browser || !ready) return;
-    let inspected: LocalUploadFile[];
+    let inspection: LocalUploadInspection;
     try {
-      inspected = await invoke<LocalUploadFile[]>("sftp_inspect_upload_paths", {
-        paths,
-      });
+      inspection = await invoke<LocalUploadInspection>(
+        "sftp_inspect_upload_paths",
+        { paths },
+      );
     } catch (error) {
       Message.error(commandErrorMessage(error));
       return;
     }
-    if (inspected.length < paths.length) {
-      Message.warning(
-        `已跳过 ${paths.length - inspected.length} 个目录或无效路径`,
-      );
+    if (inspection.skippedPaths > 0) {
+      Message.warning(`已跳过 ${inspection.skippedPaths} 个无效或不支持的项目`);
     }
-    if (inspected.length === 0) {
-      Message.warning("没有可上传的文件");
+    if (inspection.files.length === 0 && inspection.directories.length === 0) {
+      Message.warning("没有可上传的文件或文件夹");
       return;
     }
 
-    const uniqueFiles = new Map<string, LocalUploadFile>();
-    for (const file of inspected) {
-      if (!uniqueFiles.has(file.name)) {
-        uniqueFiles.set(file.name, file);
+    const destination = targetDirectory ?? browser.path;
+    let targetEntries = browser.entries;
+    if (destination !== browser.path) {
+      try {
+        const listing = await invoke<SftpListResult>("sftp_list", {
+          sessionId: session.id,
+          path: destination,
+        });
+        targetEntries = listing.entries;
+      } catch (error) {
+        Message.error(commandErrorMessage(error));
+        return;
       }
     }
-    if (uniqueFiles.size < inspected.length) {
-      Message.warning(
-        `已跳过 ${inspected.length - uniqueFiles.size} 个同名文件`,
+
+    const directoryRoots = new Set(
+      inspection.directories.filter((path) => !path.includes("/")),
+    );
+    const rootNames = new Set([
+      ...directoryRoots,
+      ...inspection.files.map((file) => file.relativePath.split("/")[0]),
+    ]);
+    const existingEntries = new Map(
+      targetEntries.map((entry) => [entry.name, entry]),
+    );
+    const incompatibleRoot = [...rootNames].find((name) => {
+      const existing = existingEntries.get(name);
+      return (
+        existing &&
+        (directoryRoots.has(name) !== (existing.kind === "directory"))
       );
+    });
+    if (incompatibleRoot) {
+      Message.error(`远程目标“${incompatibleRoot}”与本地项目类型不一致`);
+      return;
     }
-    const files = [...uniqueFiles.values()];
-    const existingNames = new Set(browser.entries.map((entry) => entry.name));
-    const conflictCount = files.filter((file) =>
-      existingNames.has(file.name),
-    ).length;
+
+    const conflictingRoots = new Set(
+      [...rootNames].filter((name) => existingEntries.has(name)),
+    );
     if (
-      conflictCount > 0 &&
+      conflictingRoots.size > 0 &&
       !(await confirmBatchOverwrite(
-        "覆盖远程文件？",
-        `有 ${conflictCount} 个同名文件，继续后将统一覆盖。`,
+        "合并或覆盖远程项目？",
+        `有 ${conflictingRoots.size} 个同名项目，目录将合并，同名文件将覆盖。`,
       ))
     ) {
       return;
     }
 
-    for (const file of files) {
+    try {
+      await invoke("sftp_ensure_upload_directories", {
+        sessionId: session.id,
+        basePath: destination,
+        relativePaths: inspection.directories,
+      });
+    } catch (error) {
+      Message.error(commandErrorMessage(error));
+      return;
+    }
+
+    for (const file of inspection.files) {
+      const rootName = file.relativePath.split("/")[0];
       runTransfer(
         "upload",
         file.path,
-        remoteJoinPath(browser.path, file.name),
-        existingNames.has(file.name),
+        remoteJoinPath(destination, file.relativePath),
+        conflictingRoots.has(rootName),
         undefined,
         file.size,
       );
     }
-    Message.info(`已加入 ${files.length} 个上传任务`);
+    if (destination === browser.path && inspection.directories.length > 0) {
+      await loadDirectory(session.id, browser.path);
+    }
+    if (inspection.files.length > 0) {
+      Message.info(`已加入 ${inspection.files.length} 个上传任务`);
+    } else {
+      Message.success(`已创建 ${inspection.directories.length} 个目录`);
+    }
   }
 
   queueUploadPathsRef.current = queueUploadPaths;
@@ -2717,46 +2767,70 @@ function SftpPanel({
     let disposed = false;
     let unlisten: (() => void) | undefined;
     let scaleFactor = 1;
+    const currentWindow = getCurrentWindow();
 
-    void getCurrentWindow()
-      .scaleFactor()
-      .then((value) => {
-        scaleFactor = value;
-      });
-    void getCurrentWebview()
-      .onDragDropEvent(({ payload }) => {
-        if (payload.type === "leave") {
-          setFileDropActive(false);
-          return;
+    const handleDragDrop: Parameters<
+      typeof currentWindow.onDragDropEvent
+    >[0] = ({ payload }) => {
+      if (payload.type === "leave") {
+        setFileDropActive(false);
+        setFileDropTargetPath(undefined);
+        return;
+      }
+      const rect = dropZoneRef.current?.getBoundingClientRect();
+      const point = rect
+        ? resolveNativeDropPoint(
+            payload.position,
+            scaleFactor,
+            rect,
+            isApplePlatform(),
+          )
+        : undefined;
+      const x = point?.x ?? 0;
+      const y = point?.y ?? 0;
+      const inside = Boolean(readyRef.current && point?.inside);
+      const row = inside
+        ? document
+            .elementFromPoint(x, y)
+            ?.closest<HTMLElement>("[data-sftp-entry-id]")
+        : undefined;
+      const targetDirectory =
+        row?.dataset.sftpEntryKind === "directory"
+          ? row.dataset.sftpEntryPath
+          : undefined;
+      if (payload.type === "drop") {
+        setFileDropActive(false);
+        setFileDropTargetPath(undefined);
+        recordDiagnostic("info", "sftp.drag-drop", "收到本地文件拖放事件", {
+          accepted: inside,
+          coordinateMode: point?.coordinateMode ?? "unknown",
+          itemCount: payload.paths.length,
+          ready: readyRef.current,
+        });
+        if (inside) {
+          void queueUploadPathsRef.current(payload.paths, targetDirectory);
         }
-        const rect = dropZoneRef.current?.getBoundingClientRect();
-        const position = payload.position;
-        const x = position.x / scaleFactor;
-        const y = position.y / scaleFactor;
-        const inside = Boolean(
-          readyRef.current &&
-          rect &&
-          x >= rect.left &&
-          x <= rect.right &&
-          y >= rect.top &&
-          y <= rect.bottom,
-        );
-        if (payload.type === "drop") {
-          setFileDropActive(false);
-          if (inside) {
-            void queueUploadPathsRef.current(payload.paths);
-          }
-          return;
-        }
-        setFileDropActive(inside);
-      })
-      .then((stopListening) => {
+        return;
+      }
+      setFileDropActive(inside);
+      setFileDropTargetPath(targetDirectory);
+    };
+
+    void (async () => {
+      try {
+        scaleFactor = await currentWindow.scaleFactor();
+        const stopListening = await currentWindow.onDragDropEvent(handleDragDrop);
         if (disposed) {
           stopListening();
         } else {
           unlisten = stopListening;
         }
-      });
+      } catch (error) {
+        recordDiagnostic("error", "sftp.drag-drop", "注册文件拖放监听失败", {
+          error: commandErrorMessage(error),
+        });
+      }
+    })();
 
     return () => {
       disposed = true;
@@ -3008,7 +3082,12 @@ function SftpPanel({
             {fileDropActive && (
               <div className="sftp-file-drop-overlay">
                 <IconUpload />
-                <span>释放以上传文件</span>
+                <span>
+                  释放以上传文件或文件夹到
+                  {fileDropTargetPath
+                    ? `“${localFileName(fileDropTargetPath)}”`
+                    : `“${browser?.path ?? "/"}”`}
+                </span>
               </div>
             )}
             <Table
@@ -3022,6 +3101,8 @@ function SftpPanel({
               }
               onRow={(entry) => ({
                 "data-sftp-entry-id": entry.id,
+                "data-sftp-entry-kind": entry.kind,
+                "data-sftp-entry-path": entry.path,
                 onDoubleClick: () => {
                   if (entry.kind === "directory") {
                     openDirectory(entry);
@@ -3036,6 +3117,9 @@ function SftpPanel({
                 [
                   cutEntryPaths.has(entry.path) ? "sftp-row-cut" : "",
                   remoteDropTargetPath === entry.path
+                    ? "sftp-row-drop-target"
+                    : "",
+                  fileDropTargetPath === entry.path
                     ? "sftp-row-drop-target"
                     : "",
                 ]

--- a/src/components/SftpPanel.tsx
+++ b/src/components/SftpPanel.tsx
@@ -167,6 +167,7 @@ interface SftpPanelProps {
   refreshRequest: number;
   session: TerminalSession | null;
   showHiddenFiles: boolean;
+  terminalDirectory?: { path: string; revision: number };
 }
 
 type TransferRecord = TransferActivityRecord;
@@ -277,6 +278,7 @@ function SftpPanel({
   refreshRequest,
   session,
   showHiddenFiles,
+  terminalDirectory,
 }: SftpPanelProps) {
   const [browsers, setBrowsers] = useState<Record<string, BrowserState>>({});
   const [transfers, setTransfers] = useState<Record<string, TransferRecord>>(
@@ -335,6 +337,9 @@ function SftpPanel({
   const connectedHomesRef = useRef(new Map<string, string>());
   const startingTransfersRef = useRef(new Set<string>());
   const handledRefreshRequestsRef = useRef<Record<string, number>>({});
+  const handledTerminalDirectoryRevisionsRef = useRef(
+    new Map<string, number>(),
+  );
   const browsersRef = useRef(browsers);
   const transfersRef = useRef(transfers);
   const panelRef = useRef<HTMLElement>(null);
@@ -808,6 +813,28 @@ function SftpPanel({
       textEditor ? new TextEncoder().encode(textEditor.content).byteLength : 0,
     [textEditor],
   );
+
+  useEffect(() => {
+    if (!session) return;
+    if (!terminalDirectory) {
+      handledTerminalDirectoryRevisionsRef.current.delete(session.id);
+      return;
+    }
+    if (browser?.status !== "ready") return;
+    if (
+      handledTerminalDirectoryRevisionsRef.current.get(session.id) ===
+      terminalDirectory.revision
+    ) {
+      return;
+    }
+    handledTerminalDirectoryRevisionsRef.current.set(
+      session.id,
+      terminalDirectory.revision,
+    );
+    if (browser.path !== terminalDirectory.path) {
+      void loadDirectory(session.id, terminalDirectory.path);
+    }
+  }, [browser?.path, browser?.status, loadDirectory, session, terminalDirectory]);
 
   useEffect(() => {
     onCurrentPathChange(

--- a/src/components/SftpPanel.tsx
+++ b/src/components/SftpPanel.tsx
@@ -103,6 +103,7 @@ import {
   resolveNativeDropPoint,
   selectAllSftpEntryKeys,
   setRemotePathBookmark,
+  summarizeSftpTransferBatch,
 } from "../sftp-utils";
 import type { PermissionFlag, RemoteArchiveFormat } from "../sftp-utils";
 import { jumpHostRequest, sshCredentialId } from "../terminal-utils";
@@ -246,6 +247,10 @@ function createTransferId() {
   return `transfer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function createUploadBatchId() {
+  return `upload-batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 function isTransferCancellation(message: string) {
   return /传输已取消|连接已取消|cancel(?:led|ed)/i.test(message);
 }
@@ -344,6 +349,7 @@ function SftpPanel({
   const connectingRef = useRef(new Set<string>());
   const connectedHomesRef = useRef(new Map<string, string>());
   const startingTransfersRef = useRef(new Set<string>());
+  const finalizedUploadBatchesRef = useRef(new Set<string>());
   const handledRefreshRequestsRef = useRef<Record<string, number>>({});
   const handledTerminalDirectoryRevisionsRef = useRef(
     new Map<string, number>(),
@@ -1049,12 +1055,14 @@ function SftpPanel({
             },
           );
         }
-        Message.success(
-          `${transfer.direction === "upload" ? "上传" : "下载"}完成：${transfer.fileName}`,
-        );
-        const currentBrowser = browsersRef.current[transfer.sessionId];
-        if (transfer.direction === "upload" && currentBrowser) {
-          await loadDirectory(transfer.sessionId, currentBrowser.path);
+        if (!transfer.batchId) {
+          Message.success(
+            `${transfer.direction === "upload" ? "上传" : "下载"}完成：${transfer.fileName}`,
+          );
+          const currentBrowser = browsersRef.current[transfer.sessionId];
+          if (transfer.direction === "upload" && currentBrowser) {
+            await loadDirectory(transfer.sessionId, currentBrowser.path);
+          }
         }
       } catch (error) {
         const message = commandErrorMessage(error);
@@ -1081,7 +1089,7 @@ function SftpPanel({
               error: message,
             });
           }
-          Message.error(message);
+          if (!transfer.batchId) Message.error(message);
         }
       } finally {
         startingTransfersRef.current.delete(transfer.transferId);
@@ -1089,6 +1097,45 @@ function SftpPanel({
     },
     [loadDirectory, updateBrowser],
   );
+
+  useEffect(() => {
+    const batches = new Map<string, TransferRecord[]>();
+    for (const transfer of Object.values(transfers)) {
+      if (transfer.direction !== "upload" || !transfer.batchId) continue;
+      const batch = batches.get(transfer.batchId) ?? [];
+      batch.push(transfer);
+      batches.set(transfer.batchId, batch);
+    }
+
+    for (const batchId of finalizedUploadBatchesRef.current) {
+      if (!batches.has(batchId)) finalizedUploadBatchesRef.current.delete(batchId);
+    }
+
+    for (const [batchId, batch] of batches) {
+      if (finalizedUploadBatchesRef.current.has(batchId)) continue;
+      const summary = summarizeSftpTransferBatch(
+        batch.map((transfer) => transfer.status),
+      );
+      if (!summary.finished) continue;
+
+      finalizedUploadBatchesRef.current.add(batchId);
+      if (summary.failed === 0 && summary.cancelled === 0) {
+        Message.success(`上传完成：共 ${summary.completed} 个文件`);
+      } else {
+        const details = [`成功 ${summary.completed} 个`];
+        if (summary.failed > 0) details.push(`失败 ${summary.failed} 个`);
+        if (summary.cancelled > 0) details.push(`取消 ${summary.cancelled} 个`);
+        const message = `批量上传结束：${details.join("，")}`;
+        if (summary.failed === summary.total) Message.error(message);
+        else Message.warning(message);
+      }
+
+      const currentBrowser = browsersRef.current[batch[0].sessionId];
+      if (currentBrowser?.status === "ready") {
+        void loadDirectory(batch[0].sessionId, currentBrowser.path);
+      }
+    }
+  }, [loadDirectory, transfers]);
 
   useEffect(() => {
     if (!isTauri()) return;
@@ -1131,6 +1178,7 @@ function SftpPanel({
     overwrite: boolean,
     transferId = createTransferId(),
     totalBytes = 0,
+    batchId?: string,
   ) {
     if (!session) return;
     const fileName =
@@ -1151,6 +1199,7 @@ function SftpPanel({
       sampledAt: Date.now(),
       sampledBytes: 0,
       bytesPerSecond: 0,
+      batchId,
     };
     setTransfers((current) => ({ ...current, [transferId]: record }));
   }
@@ -1283,6 +1332,8 @@ function SftpPanel({
       return;
     }
 
+    const batchId =
+      inspection.files.length > 1 ? createUploadBatchId() : undefined;
     for (const file of inspection.files) {
       const rootName = file.relativePath.split("/")[0];
       runTransfer(
@@ -1292,9 +1343,14 @@ function SftpPanel({
         conflictingRoots.has(rootName),
         undefined,
         file.size,
+        batchId,
       );
     }
-    if (destination === browser.path && inspection.directories.length > 0) {
+    if (
+      destination === browser.path &&
+      inspection.directories.length > 0 &&
+      inspection.files.length === 0
+    ) {
       await loadDirectory(session.id, browser.path);
     }
     if (inspection.files.length > 0) {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -68,6 +68,7 @@ interface TerminalViewProps {
   session: TerminalSession;
   onAskAi: (selection: string) => void;
   onCommandLifecycle: (event: TerminalCommandSubmission) => void;
+  onCurrentDirectoryChange: (sessionId: string, path: string) => void;
   onRecentOutputChange: (output: string) => void;
   onSelectionChange: (selection: string) => void;
 }
@@ -129,6 +130,7 @@ function TerminalView({
   session,
   onAskAi,
   onCommandLifecycle,
+  onCurrentDirectoryChange,
   onRecentOutputChange,
   onSelectionChange,
 }: TerminalViewProps) {
@@ -140,7 +142,7 @@ function TerminalView({
   const connectedRef = useRef(session.status === "connected");
   const commandLifecycleRef = useRef(onCommandLifecycle);
   const commandTrackingEnabledRef = useRef(commandTrackingEnabled);
-  const shellIntegrationEnabledRef = useRef(settings.aiShellIntegrationEnabled);
+  const shellCommandResultsEnabledRef = useRef(commandTrackingEnabled);
   const shellIntegrationInstalledRef = useRef(false);
   const shellIntegrationNonceRef = useRef(createShellIntegrationNonce());
   const shellIntegrationStateRef = useRef<
@@ -161,6 +163,7 @@ function TerminalView({
   const lastInjectedInputIdRef = useRef<string>();
   const recentOutputChangeRef = useRef(onRecentOutputChange);
   const selectionChangeRef = useRef(onSelectionChange);
+  const currentDirectoryChangeRef = useRef(onCurrentDirectoryChange);
   const settingsRef = useRef(settings);
   const searchVisibleRef = useRef(false);
   const lastStatusNoticeRef = useRef<string>();
@@ -175,8 +178,8 @@ function TerminalView({
   settingsRef.current = settings;
   commandLifecycleRef.current = onCommandLifecycle;
   commandTrackingEnabledRef.current = commandTrackingEnabled;
-  shellIntegrationEnabledRef.current =
-    commandTrackingEnabled && settings.aiShellIntegrationEnabled;
+  shellCommandResultsEnabledRef.current = commandTrackingEnabled;
+  currentDirectoryChangeRef.current = onCurrentDirectoryChange;
   recentOutputChangeRef.current = onRecentOutputChange;
   selectionChangeRef.current = onSelectionChange;
 
@@ -238,6 +241,7 @@ function TerminalView({
   useEffect(() => {
     connectedRef.current = session.status === "connected";
     if (session.status !== "connected") {
+      currentDirectoryChangeRef.current(session.id, "");
       const completedAt = new Date().toISOString();
       for (const pending of pendingShellCommandsRef.current) {
         commandLifecycleRef.current({
@@ -268,30 +272,14 @@ function TerminalView({
 
   useEffect(() => {
     if (session.status !== "connected" || !terminalReady) return;
-    const enabled =
-      commandTrackingEnabled && settings.aiShellIntegrationEnabled;
-    if (enabled && !shellIntegrationInstalledRef.current) {
+    if (!shellIntegrationInstalledRef.current) {
       if (!inputStateRef.current.reliable || inputStateRef.current.value) {
         shellIntegrationStateRef.current = "unavailable";
         return;
       }
       startShellIntegrationMutationRef.current("install");
-      return;
     }
-    if (!enabled && shellIntegrationInstalledRef.current) {
-      pendingShellCommandsRef.current = [];
-      if (!inputStateRef.current.reliable || inputStateRef.current.value) {
-        return;
-      }
-      startShellIntegrationMutationRef.current("uninstall");
-    }
-  }, [
-    commandTrackingEnabled,
-    session.id,
-    session.status,
-    settings.aiShellIntegrationEnabled,
-    terminalReady,
-  ]);
+  }, [session.id, session.status, terminalReady]);
 
   useEffect(() => {
     if (
@@ -389,7 +377,7 @@ function TerminalView({
             submittedAt,
           };
           commandLifecycleRef.current(submission);
-          if (!shellIntegrationEnabledRef.current) continue;
+          if (!shellCommandResultsEnabledRef.current) continue;
           if (shellIntegrationStateRef.current === "ready") {
             const buffer = terminal.buffer.active;
             pendingShellCommandsRef.current.push({
@@ -445,24 +433,23 @@ function TerminalView({
         if (!message) return false;
         if (message.kind === "ready") {
           settleShellIntegrationMutationRef.current("ready");
-          if (!shellIntegrationEnabledRef.current) {
-            queueMicrotask(() =>
-              startShellIntegrationMutationRef.current("uninstall"),
-            );
-          }
           return true;
         }
         if (message.kind === "disabled") {
           settleShellIntegrationMutationRef.current("disabled");
-          if (shellIntegrationEnabledRef.current) {
-            queueMicrotask(() =>
-              startShellIntegrationMutationRef.current("install"),
-            );
-          }
+          currentDirectoryChangeRef.current(session.id, "");
+          queueMicrotask(() =>
+            startShellIntegrationMutationRef.current("install"),
+          );
+          return true;
+        }
+        if (message.kind === "cwd") {
+          currentDirectoryChangeRef.current(session.id, message.path);
           return true;
         }
         if (message.kind === "unavailable") {
           settleShellIntegrationMutationRef.current("unavailable");
+          currentDirectoryChangeRef.current(session.id, "");
           const completedAt = new Date().toISOString();
           for (const pending of pendingShellCommandsRef.current) {
             commandLifecycleRef.current({

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -48,8 +48,11 @@ import {
   boundedShellCommandOutput,
   buildShellIntegrationInstallCommand,
   buildShellIntegrationUninstallCommand,
+  createShellIntegrationEchoFilter,
   createShellIntegrationNonce,
+  filterShellIntegrationEcho,
   parseShellIntegrationMessage,
+  type ShellIntegrationEchoFilter,
 } from "../shell-integration";
 import { TERMINAL_THEMES } from "../terminal-themes";
 import { diagnosticInvoke as invoke } from "../diagnostics";
@@ -74,6 +77,10 @@ interface PendingShellCommand {
   startedAtMs: number;
   submission: TerminalCommandSubmission;
 }
+
+type ShellIntegrationMutation = "install" | "uninstall";
+
+const SHELL_INTEGRATION_TIMEOUT_MS = 8_000;
 
 const EMPTY_SEARCH_RESULT: ISearchResultChangeEvent = {
   resultCount: 0,
@@ -139,6 +146,15 @@ function TerminalView({
   const shellIntegrationStateRef = useRef<
     "disabled" | "installing" | "ready" | "unavailable"
   >("disabled");
+  const shellIntegrationMutationRef = useRef<ShellIntegrationMutation>();
+  const shellIntegrationEchoFilterRef = useRef<ShellIntegrationEchoFilter>();
+  const shellIntegrationTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const startShellIntegrationMutationRef = useRef<
+    (mutation: ShellIntegrationMutation) => void
+  >(() => undefined);
+  const settleShellIntegrationMutationRef = useRef<
+    (result: "ready" | "disabled" | "unavailable") => void
+  >(() => undefined);
   const pendingShellCommandsRef = useRef<PendingShellCommand[]>([]);
   const aiCommandCandidatesRef = useRef<string[]>([]);
   const inputStateRef = useRef({ ...EMPTY_TERMINAL_INPUT_STATE });
@@ -164,6 +180,61 @@ function TerminalView({
   recentOutputChangeRef.current = onRecentOutputChange;
   selectionChangeRef.current = onSelectionChange;
 
+  const clearShellIntegrationTimeout = () => {
+    if (!shellIntegrationTimeoutRef.current) return;
+    clearTimeout(shellIntegrationTimeoutRef.current);
+    shellIntegrationTimeoutRef.current = undefined;
+  };
+
+  settleShellIntegrationMutationRef.current = (result) => {
+    const mutation = shellIntegrationMutationRef.current;
+    clearShellIntegrationTimeout();
+    shellIntegrationMutationRef.current = undefined;
+    shellIntegrationEchoFilterRef.current = undefined;
+    if (result === "ready") {
+      shellIntegrationInstalledRef.current = true;
+      shellIntegrationStateRef.current = "ready";
+    } else if (result === "disabled") {
+      shellIntegrationInstalledRef.current = false;
+      shellIntegrationStateRef.current = "disabled";
+    } else {
+      shellIntegrationInstalledRef.current = mutation === "uninstall";
+      shellIntegrationStateRef.current = "unavailable";
+    }
+  };
+
+  startShellIntegrationMutationRef.current = (mutation) => {
+    if (session.status !== "connected" || shellIntegrationMutationRef.current) {
+      return;
+    }
+    shellIntegrationMutationRef.current = mutation;
+    if (mutation === "install") {
+      shellIntegrationInstalledRef.current = true;
+      shellIntegrationStateRef.current = "installing";
+    }
+    const command =
+      mutation === "install"
+        ? buildShellIntegrationInstallCommand(shellIntegrationNonceRef.current)
+        : buildShellIntegrationUninstallCommand(
+            shellIntegrationNonceRef.current,
+          );
+    shellIntegrationEchoFilterRef.current = createShellIntegrationEchoFilter(
+      shellIntegrationNonceRef.current,
+      mutation,
+    );
+    clearShellIntegrationTimeout();
+    shellIntegrationTimeoutRef.current = setTimeout(() => {
+      if (shellIntegrationMutationRef.current !== mutation) return;
+      settleShellIntegrationMutationRef.current("unavailable");
+    }, SHELL_INTEGRATION_TIMEOUT_MS);
+    void invoke("ssh_write", {
+      sessionId: session.id,
+      data: Array.from(new TextEncoder().encode(command)),
+    }).catch(() => {
+      settleShellIntegrationMutationRef.current("unavailable");
+    });
+  };
+
   useEffect(() => {
     connectedRef.current = session.status === "connected";
     if (session.status !== "connected") {
@@ -180,6 +251,9 @@ function TerminalView({
       pendingShellCommandsRef.current = [];
       shellIntegrationInstalledRef.current = false;
       shellIntegrationStateRef.current = "disabled";
+      shellIntegrationMutationRef.current = undefined;
+      shellIntegrationEchoFilterRef.current = undefined;
+      clearShellIntegrationTimeout();
       aiCommandCandidatesRef.current = [];
       inputStateRef.current = { ...EMPTY_TERMINAL_INPUT_STATE };
     }
@@ -201,18 +275,7 @@ function TerminalView({
         shellIntegrationStateRef.current = "unavailable";
         return;
       }
-      shellIntegrationInstalledRef.current = true;
-      shellIntegrationStateRef.current = "installing";
-      const command = buildShellIntegrationInstallCommand(
-        shellIntegrationNonceRef.current,
-      );
-      void invoke("ssh_write", {
-        sessionId: session.id,
-        data: Array.from(new TextEncoder().encode(command)),
-      }).catch(() => {
-        shellIntegrationInstalledRef.current = false;
-        shellIntegrationStateRef.current = "unavailable";
-      });
+      startShellIntegrationMutationRef.current("install");
       return;
     }
     if (!enabled && shellIntegrationInstalledRef.current) {
@@ -220,13 +283,7 @@ function TerminalView({
       if (!inputStateRef.current.reliable || inputStateRef.current.value) {
         return;
       }
-      shellIntegrationStateRef.current = "disabled";
-      shellIntegrationInstalledRef.current = false;
-      const command = buildShellIntegrationUninstallCommand();
-      void invoke("ssh_write", {
-        sessionId: session.id,
-        data: Array.from(new TextEncoder().encode(command)),
-      }).catch(() => undefined);
+      startShellIntegrationMutationRef.current("uninstall");
     }
   }, [
     commandTrackingEnabled,
@@ -311,7 +368,7 @@ function TerminalView({
     scheduleFit();
 
     const dataDisposable = terminal.onData((data) => {
-      if (!connectedRef.current) return;
+      if (!connectedRef.current || shellIntegrationMutationRef.current) return;
       if (commandTrackingEnabledRef.current) {
         const tracked = trackTerminalInput(inputStateRef.current, data);
         inputStateRef.current = tracked.state;
@@ -387,11 +444,25 @@ function TerminalView({
         );
         if (!message) return false;
         if (message.kind === "ready") {
-          shellIntegrationStateRef.current = "ready";
+          settleShellIntegrationMutationRef.current("ready");
+          if (!shellIntegrationEnabledRef.current) {
+            queueMicrotask(() =>
+              startShellIntegrationMutationRef.current("uninstall"),
+            );
+          }
+          return true;
+        }
+        if (message.kind === "disabled") {
+          settleShellIntegrationMutationRef.current("disabled");
+          if (shellIntegrationEnabledRef.current) {
+            queueMicrotask(() =>
+              startShellIntegrationMutationRef.current("install"),
+            );
+          }
           return true;
         }
         if (message.kind === "unavailable") {
-          shellIntegrationStateRef.current = "unavailable";
+          settleShellIntegrationMutationRef.current("unavailable");
           const completedAt = new Date().toISOString();
           for (const pending of pendingShellCommandsRef.current) {
             commandLifecycleRef.current({
@@ -462,7 +533,18 @@ function TerminalView({
     };
     void listenProtocolEvent("ssh-output", ({ payload }) => {
       if (payload.sessionId === session.id) {
-        terminal.write(decodeSshOutput(payload.data), scheduleRecentOutput);
+        let data: Uint8Array<ArrayBufferLike> = decodeSshOutput(payload.data);
+        if (shellIntegrationEchoFilterRef.current) {
+          const filtered = filterShellIntegrationEcho(
+            shellIntegrationEchoFilterRef.current,
+            data,
+          );
+          data = filtered.data;
+          shellIntegrationEchoFilterRef.current = filtered.filter;
+        }
+        if (data.length > 0) {
+          terminal.write(data, scheduleRecentOutput);
+        }
       }
     }).then((stopListening) => {
       if (disposed) {
@@ -476,6 +558,9 @@ function TerminalView({
     return () => {
       disposed = true;
       setTerminalReady(false);
+      clearShellIntegrationTimeout();
+      shellIntegrationMutationRef.current = undefined;
+      shellIntegrationEchoFilterRef.current = undefined;
       unlisten?.();
       if (recentOutputTimer) clearTimeout(recentOutputTimer);
       resizeObserver.disconnect();

--- a/src/components/TransferActivityList.tsx
+++ b/src/components/TransferActivityList.tsx
@@ -37,6 +37,7 @@ export interface TransferActivityRecord
   sampledAt: number;
   sampledBytes: number;
   bytesPerSecond: number;
+  batchId?: string;
   archiveFormat?: RemoteArchiveFormat;
   archiveSourcePaths?: string[];
 }

--- a/src/host-organization.test.ts
+++ b/src/host-organization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { HostRecord } from "./models";
 import {
   buildHostTableTree,
+  collectHostGroupPaths,
   createHostCopy,
   hostGroupKey,
   normalizeGroupPath,
@@ -35,6 +36,15 @@ describe("host group organization", () => {
   test("normalizes nested group paths", () => {
     expect(normalizeGroupPath(" 生产 / 华东 / ")).toBe("生产/华东");
     expect(normalizeGroupPath(" / / ")).toBeUndefined();
+  });
+
+  test("collects selectable group paths including parent groups", () => {
+    expect(collectHostGroupPaths(hosts)).toEqual([
+      "测试",
+      "生产",
+      "生产/华东",
+      "生产/华西",
+    ]);
   });
 
   test("builds grouped table rows and keeps ungrouped hosts at root", () => {

--- a/src/host-organization.ts
+++ b/src/host-organization.ts
@@ -38,6 +38,23 @@ export function normalizeGroupPath(group?: string) {
   return normalized || undefined;
 }
 
+export function collectHostGroupPaths(hosts: HostRecord[]) {
+  const paths = new Set<string>();
+  for (const host of hosts) {
+    const group = normalizeGroupPath(host.group);
+    if (!group) continue;
+
+    let currentPath = "";
+    for (const segment of group.split("/")) {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      paths.add(currentPath);
+    }
+  }
+  return [...paths].sort((left, right) =>
+    left.localeCompare(right, "zh-CN", { numeric: true }),
+  );
+}
+
 export function hostGroupKey(path: string) {
   return `${HOST_GROUP_KEY_PREFIX}${path}`;
 }

--- a/src/sftp-utils.test.ts
+++ b/src/sftp-utils.test.ts
@@ -19,6 +19,7 @@ import {
   remoteArchiveFormatFromName,
   remoteJoinPath,
   remoteParentPath,
+  resolveNativeDropPoint,
   selectAllSftpEntryKeys,
   invertSftpEntryKeys,
   setRemotePathBookmark,
@@ -120,6 +121,59 @@ describe("SFTP selection helpers", () => {
       "a",
       "c",
     ]);
+  });
+});
+
+describe("SFTP native drop coordinates", () => {
+  const bounds = { left: 500, right: 1_200, top: 400, bottom: 800 };
+
+  test("keeps AppKit logical coordinates on a Retina display", () => {
+    expect(
+      resolveNativeDropPoint({ x: 900, y: 650 }, 2, bounds, true),
+    ).toEqual({
+      x: 900,
+      y: 650,
+      inside: true,
+      coordinateMode: "logical",
+    });
+  });
+
+  test("converts physical coordinates when that is the matching coordinate space", () => {
+    expect(
+      resolveNativeDropPoint(
+        { x: 900, y: 600 },
+        1.5,
+        { left: 500, right: 800, top: 300, bottom: 500 },
+        false,
+      ),
+    ).toEqual({
+      x: 600,
+      y: 400,
+      inside: true,
+      coordinateMode: "physical",
+    });
+  });
+
+  test("falls back to the alternate coordinate space when it is the only match", () => {
+    expect(
+      resolveNativeDropPoint({ x: 900, y: 650 }, 2, bounds, false),
+    ).toEqual({
+      x: 900,
+      y: 650,
+      inside: true,
+      coordinateMode: "logical",
+    });
+  });
+
+  test("reports points outside the panel without producing invalid values", () => {
+    expect(
+      resolveNativeDropPoint({ x: 100, y: 100 }, Number.NaN, bounds, true),
+    ).toEqual({
+      x: 100,
+      y: 100,
+      inside: false,
+      coordinateMode: "logical",
+    });
   });
 });
 

--- a/src/sftp-utils.test.ts
+++ b/src/sftp-utils.test.ts
@@ -23,6 +23,7 @@ import {
   selectAllSftpEntryKeys,
   invertSftpEntryKeys,
   setRemotePathBookmark,
+  summarizeSftpTransferBatch,
 } from "./sftp-utils";
 
 describe("SFTP path helpers", () => {
@@ -121,6 +122,43 @@ describe("SFTP selection helpers", () => {
       "a",
       "c",
     ]);
+  });
+});
+
+describe("SFTP transfer batches", () => {
+  test("keeps a batch active while any transfer is queued or running", () => {
+    expect(
+      summarizeSftpTransferBatch(["completed", "running", "queued"]),
+    ).toEqual({
+      total: 3,
+      completed: 1,
+      failed: 0,
+      cancelled: 0,
+      active: 2,
+      finished: false,
+    });
+  });
+
+  test("summarizes all terminal results when a batch finishes", () => {
+    expect(
+      summarizeSftpTransferBatch([
+        "completed",
+        "completed",
+        "failed",
+        "cancelled",
+      ]),
+    ).toEqual({
+      total: 4,
+      completed: 2,
+      failed: 1,
+      cancelled: 1,
+      active: 0,
+      finished: true,
+    });
+  });
+
+  test("does not treat an empty collection as a finished batch", () => {
+    expect(summarizeSftpTransferBatch([]).finished).toBe(false);
   });
 });
 

--- a/src/sftp-utils.ts
+++ b/src/sftp-utils.ts
@@ -176,6 +176,40 @@ export function isActiveSftpTransfer(status: SftpTransferStatus) {
   return status === "queued" || status === "running" || status === "paused";
 }
 
+export interface SftpTransferBatchSummary {
+  total: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  active: number;
+  finished: boolean;
+}
+
+export function summarizeSftpTransferBatch(
+  statuses: readonly SftpTransferStatus[],
+): SftpTransferBatchSummary {
+  const summary = statuses.reduce<SftpTransferBatchSummary>(
+    (current, status) => {
+      current.total += 1;
+      if (status === "completed") current.completed += 1;
+      else if (status === "failed") current.failed += 1;
+      else if (status === "cancelled") current.cancelled += 1;
+      else current.active += 1;
+      return current;
+    },
+    {
+      total: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+      active: 0,
+      finished: false,
+    },
+  );
+  summary.finished = summary.total > 0 && summary.active === 0;
+  return summary;
+}
+
 export function isValidRemoteName(name: string) {
   const trimmed = name.trim();
   return (

--- a/src/sftp-utils.ts
+++ b/src/sftp-utils.ts
@@ -88,6 +88,70 @@ export function localFileName(path: string) {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
+export interface NativeDropPoint {
+  x: number;
+  y: number;
+  inside: boolean;
+  coordinateMode: "logical" | "physical";
+}
+
+interface NativeDropPosition {
+  x: number;
+  y: number;
+}
+
+interface NativeDropBounds {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+function isPointInsideBounds(
+  point: NativeDropPosition,
+  bounds: NativeDropBounds,
+) {
+  return (
+    point.x >= bounds.left &&
+    point.x <= bounds.right &&
+    point.y >= bounds.top &&
+    point.y <= bounds.bottom
+  );
+}
+
+export function resolveNativeDropPoint(
+  position: NativeDropPosition,
+  scaleFactor: number,
+  bounds: NativeDropBounds,
+  preferLogicalCoordinates: boolean,
+): NativeDropPoint {
+  const normalizedScaleFactor =
+    Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1;
+  const logical = { x: position.x, y: position.y };
+  const physical = {
+    x: position.x / normalizedScaleFactor,
+    y: position.y / normalizedScaleFactor,
+  };
+  const candidates = preferLogicalCoordinates
+    ? [
+        { point: logical, coordinateMode: "logical" as const },
+        { point: physical, coordinateMode: "physical" as const },
+      ]
+    : [
+        { point: physical, coordinateMode: "physical" as const },
+        { point: logical, coordinateMode: "logical" as const },
+      ];
+  const matched = candidates.find(({ point }) =>
+    isPointInsideBounds(point, bounds),
+  );
+  const resolved = matched ?? candidates[0];
+  return {
+    ...resolved.point,
+    inside: Boolean(matched),
+    coordinateMode: resolved.coordinateMode,
+  };
+}
+
 export function selectAllSftpEntryKeys(visibleKeys: readonly string[]) {
   return [...visibleKeys];
 }

--- a/src/shell-integration.test.ts
+++ b/src/shell-integration.test.ts
@@ -5,6 +5,8 @@ import {
   boundedShellCommandOutput,
   buildShellIntegrationInstallCommand,
   buildShellIntegrationUninstallCommand,
+  createShellIntegrationEchoFilter,
+  filterShellIntegrationEcho,
   parseShellIntegrationMessage,
 } from "./shell-integration";
 
@@ -23,6 +25,9 @@ describe("shell integration", () => {
       ),
     ).toEqual({ kind: "unavailable", reason: "unsupported-shell" });
     expect(
+      parseShellIntegrationMessage("FineShell;nonce;disabled;tty", "nonce"),
+    ).toEqual({ kind: "disabled" });
+    expect(
       parseShellIntegrationMessage("FineShell;other;end;0", "nonce"),
     ).toBeNull();
     expect(
@@ -37,11 +42,68 @@ describe("shell integration", () => {
     expect(install).toContain("ZSH_VERSION");
     expect(install).toContain("PROMPT_COMMAND");
     expect(install).toContain("add-zsh-hook");
+    expect(install).toContain("history -d");
     expect(install.endsWith("\r")).toBe(true);
 
-    const uninstall = buildShellIntegrationUninstallCommand();
+    const uninstall = buildShellIntegrationUninstallCommand("safe-nonce");
     expect(uninstall).toContain("__fineshell_pc_decl");
     expect(uninstall).toContain("add-zsh-hook -d");
+    expect(uninstall).toContain("disabled;tty");
+  });
+
+  test("gates redrawn installation input until the authenticated result arrives", () => {
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const marker = `\r\u001b[2K\u001b]${FINESHELL_OSC_ID};FineShell;stream-nonce;ready;zsh\u0007`;
+    const redrawnEcho =
+      "ubuntu@server:~$ stty -ec\r<server:~$ stty -echo\b\b\b\b\b";
+    const combined = encoder.encode(`${redrawnEcho}\r\n${marker}next prompt`);
+    const splitAt = redrawnEcho.length + Math.floor(marker.length / 2);
+    let filter = createShellIntegrationEchoFilter("stream-nonce", "install");
+
+    const first = filterShellIntegrationEcho(
+      filter,
+      combined.slice(0, splitAt),
+    );
+    expect(first.data).toHaveLength(0);
+    expect(first.filter).toBeDefined();
+    filter = first.filter!;
+
+    const second = filterShellIntegrationEcho(filter, combined.slice(splitAt));
+    expect(decoder.decode(second.data)).toBe(`${marker}next prompt`);
+    expect(second.filter).toBeUndefined();
+  });
+
+  test("does not accept a marker created for another session", () => {
+    const encoder = new TextEncoder();
+    const filter = createShellIntegrationEchoFilter(
+      "expected-nonce",
+      "install",
+    );
+    const result = filterShellIntegrationEcho(
+      filter,
+      encoder.encode(
+        `\r\u001b[2K\u001b]${FINESHELL_OSC_ID};FineShell;other-nonce;ready;bash\u0007`,
+      ),
+    );
+    expect(result.data).toHaveLength(0);
+    expect(result.filter).toBeDefined();
+  });
+
+  test("gates uninstallation output until its disabled marker", () => {
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const marker = `\r\u001b[2K\u001b]${FINESHELL_OSC_ID};FineShell;disable-nonce;disabled;tty\u0007`;
+    const filter = createShellIntegrationEchoFilter(
+      "disable-nonce",
+      "uninstall",
+    );
+    const result = filterShellIntegrationEcho(
+      filter,
+      encoder.encode(`internal uninstall command${marker}prompt`),
+    );
+    expect(decoder.decode(result.data)).toBe(`${marker}prompt`);
+    expect(result.filter).toBeUndefined();
   });
 
   test("keeps only the bounded tail of a command result", () => {

--- a/src/shell-integration.test.ts
+++ b/src/shell-integration.test.ts
@@ -28,6 +28,18 @@ describe("shell integration", () => {
       parseShellIntegrationMessage("FineShell;nonce;disabled;tty", "nonce"),
     ).toEqual({ kind: "disabled" });
     expect(
+      parseShellIntegrationMessage(
+        "FineShell;nonce;cwd;/srv/apps;preview",
+        "nonce",
+      ),
+    ).toEqual({ kind: "cwd", path: "/srv/apps;preview" });
+    expect(
+      parseShellIntegrationMessage("FineShell;nonce;cwd;relative", "nonce"),
+    ).toBeNull();
+    expect(
+      parseShellIntegrationMessage("FineShell;nonce;cwd;/tmp\nunsafe", "nonce"),
+    ).toBeNull();
+    expect(
       parseShellIntegrationMessage("FineShell;other;end;0", "nonce"),
     ).toBeNull();
     expect(
@@ -42,6 +54,8 @@ describe("shell integration", () => {
     expect(install).toContain("ZSH_VERSION");
     expect(install).toContain("PROMPT_COMMAND");
     expect(install).toContain("add-zsh-hook");
+    expect(install).toContain("cwd;%s");
+    expect(install).toContain('"$PWD"');
     expect(install).toContain("history -d");
     expect(install.endsWith("\r")).toBe(true);
 

--- a/src/shell-integration.ts
+++ b/src/shell-integration.ts
@@ -3,8 +3,16 @@ export const MAX_SHELL_COMMAND_RESULT_CHARS = 12_000;
 
 export type ShellIntegrationMessage =
   | { kind: "ready"; shell: "bash" | "zsh" }
+  | { kind: "disabled" }
   | { kind: "end"; exitCode: number }
   | { kind: "unavailable"; reason: string };
+
+export interface ShellIntegrationEchoFilter {
+  markers: Uint8Array[];
+  pending: Uint8Array;
+}
+
+const MAX_SHELL_INTEGRATION_HANDSHAKE_BYTES = 32_768;
 
 function shellSingleQuote(value: string) {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
@@ -30,6 +38,9 @@ export function parseShellIntegrationMessage(
   if (kind === "ready" && (value === "bash" || value === "zsh")) {
     return { kind, shell: value };
   }
+  if (kind === "disabled" && value === "tty") {
+    return { kind };
+  }
   if (kind === "end" && /^\d{1,3}$/.test(value ?? "")) {
     const exitCode = Number(value);
     return exitCode <= 255 ? { kind, exitCode } : null;
@@ -40,6 +51,85 @@ export function parseShellIntegrationMessage(
   return null;
 }
 
+function concatBytes(left: Uint8Array, right: Uint8Array) {
+  const result = new Uint8Array(left.length + right.length);
+  result.set(left);
+  result.set(right, left.length);
+  return result;
+}
+
+function findBytes(value: Uint8Array, pattern: Uint8Array) {
+  const lastStart = value.length - pattern.length;
+  for (let start = 0; start <= lastStart; start += 1) {
+    let matches = true;
+    for (let index = 0; index < pattern.length; index += 1) {
+      if (value[start + index] !== pattern[index]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return start;
+  }
+  return -1;
+}
+
+function lifecycleMarker(nonce: string, kind: string, value: string) {
+  return new TextEncoder().encode(
+    `\r\u001b[2K\u001b]${FINESHELL_OSC_ID};FineShell;${nonce};${kind};${value}\u0007`,
+  );
+}
+
+export function createShellIntegrationEchoFilter(
+  nonce: string,
+  mutation: "install" | "uninstall",
+): ShellIntegrationEchoFilter {
+  return {
+    markers:
+      mutation === "install"
+        ? [
+            lifecycleMarker(nonce, "ready", "bash"),
+            lifecycleMarker(nonce, "ready", "zsh"),
+            lifecycleMarker(nonce, "unavailable", "unsupported-shell"),
+          ]
+        : [lifecycleMarker(nonce, "disabled", "tty")],
+    pending: new Uint8Array(),
+  };
+}
+
+export function filterShellIntegrationEcho(
+  filter: ShellIntegrationEchoFilter,
+  chunk: Uint8Array,
+): { data: Uint8Array; filter?: ShellIntegrationEchoFilter } {
+  const value = concatBytes(filter.pending, chunk);
+  const matchIndex = filter.markers.reduce((earliest, marker) => {
+    const index = findBytes(value, marker);
+    return index >= 0 && (earliest < 0 || index < earliest) ? index : earliest;
+  }, -1);
+  if (matchIndex >= 0) {
+    return { data: value.slice(matchIndex) };
+  }
+
+  return {
+    data: new Uint8Array(),
+    filter: {
+      ...filter,
+      pending: value.slice(-MAX_SHELL_INTEGRATION_HANDSHAKE_BYTES),
+    },
+  };
+}
+
+function bashHistoryCleanup(safeNonce: string) {
+  return [
+    `__fineshell_history_nonce=${safeNonce};`,
+    "for __fineshell_history_step in 1 2; do",
+    "__fineshell_history_index=$((HISTCMD-1));",
+    "__fineshell_history_line=$(history 1 2>/dev/null || true);",
+    'case "$__fineshell_history_line" in *"$__fineshell_history_nonce"*) history -d "$__fineshell_history_index" 2>/dev/null || true;; *) break;; esac;',
+    "done;",
+    "unset __fineshell_history_nonce __fineshell_history_step __fineshell_history_index __fineshell_history_line;",
+  ].join(" ");
+}
+
 export function buildShellIntegrationInstallCommand(nonce: string) {
   const safeNonce = shellSingleQuote(nonce);
   const bashMarker = `printf '\\033]${FINESHELL_OSC_ID};FineShell;%s;end;%s\\007' "$__fineshell_nonce" "$__fineshell_status"`;
@@ -47,7 +137,7 @@ export function buildShellIntegrationInstallCommand(nonce: string) {
     `printf '\\r\\033[2K\\033]${FINESHELL_OSC_ID};FineShell;%s;ready;${shell}\\007' "$__fineshell_nonce"`;
   const unavailableMarker = `printf '\\r\\033[2K\\033]${FINESHELL_OSC_ID};FineShell;%s;unavailable;unsupported-shell\\007' ${safeNonce}`;
 
-  return [
+  return ` ${[
     'if [ -n "${BASH_VERSION-}" ]; then',
     `__fineshell_nonce=${safeNonce};`,
     "__fineshell_pc_was_set=${PROMPT_COMMAND+x};",
@@ -55,6 +145,7 @@ export function buildShellIntegrationInstallCommand(nonce: string) {
     `__fineshell_prompt_command(){ __fineshell_status="$1"; ${bashMarker}; return "$__fineshell_status"; };`,
     "if declare -p PROMPT_COMMAND 2>/dev/null | grep -q 'declare -a'; then PROMPT_COMMAND=('__fineshell_prompt_command \"$?\"' \"${PROMPT_COMMAND[@]}\"); else PROMPT_COMMAND='__fineshell_prompt_command \"$?\"; '" +
       '"${PROMPT_COMMAND-}"; fi;',
+    bashHistoryCleanup(safeNonce),
     `${readyMarker("bash")};`,
     'elif [ -n "${ZSH_VERSION-}" ]; then',
     `__fineshell_nonce=${safeNonce};`,
@@ -65,20 +156,23 @@ export function buildShellIntegrationInstallCommand(nonce: string) {
     `${readyMarker("zsh")};`,
     `else ${unavailableMarker}; fi`,
     "\r",
-  ].join(" ");
+  ].join(" ")}`;
 }
 
-export function buildShellIntegrationUninstallCommand() {
-  return [
+export function buildShellIntegrationUninstallCommand(nonce: string) {
+  const safeNonce = shellSingleQuote(nonce);
+  const disabledMarker = `printf '\\r\\033[2K\\033]${FINESHELL_OSC_ID};FineShell;%s;disabled;tty\\007' ${safeNonce}`;
+  return ` ${[
     'if [ -n "${BASH_VERSION-}" ] && command -v __fineshell_prompt_command >/dev/null 2>&1; then',
     'if [ "${__fineshell_pc_was_set-}" = x ]; then eval "$__fineshell_pc_decl"; else unset PROMPT_COMMAND; fi;',
     "unset -f __fineshell_prompt_command; unset __fineshell_nonce __fineshell_pc_decl __fineshell_pc_was_set;",
+    bashHistoryCleanup(safeNonce),
     'elif [ -n "${ZSH_VERSION-}" ]; then',
     "autoload -Uz add-zsh-hook; add-zsh-hook -d precmd __fineshell_precmd 2>/dev/null || true;",
     "unfunction __fineshell_precmd 2>/dev/null || true; unset __fineshell_nonce; fi;",
-    "printf '\\r\\033[2K';",
+    `${disabledMarker};`,
     "\r",
-  ].join(" ");
+  ].join(" ")}`;
 }
 
 export function boundedShellCommandOutput(value: string) {

--- a/src/shell-integration.ts
+++ b/src/shell-integration.ts
@@ -4,6 +4,7 @@ export const MAX_SHELL_COMMAND_RESULT_CHARS = 12_000;
 export type ShellIntegrationMessage =
   | { kind: "ready"; shell: "bash" | "zsh" }
   | { kind: "disabled" }
+  | { kind: "cwd"; path: string }
   | { kind: "end"; exitCode: number }
   | { kind: "unavailable"; reason: string };
 
@@ -27,14 +28,23 @@ export function parseShellIntegrationMessage(
   data: string,
   expectedNonce: string,
 ): ShellIntegrationMessage | null {
-  const [namespace, nonce, kind, value, ...extra] = data.split(";");
-  if (
-    namespace !== "FineShell" ||
-    nonce !== expectedNonce ||
-    extra.length > 0
-  ) {
+  const [namespace, nonce, kind, ...values] = data.split(";");
+  if (namespace !== "FineShell" || nonce !== expectedNonce) {
     return null;
   }
+  const value = values[0];
+  if (kind === "cwd") {
+    const path = values.join(";");
+    if (
+      path.startsWith("/") &&
+      path.length <= 4_096 &&
+      !/[\u0000-\u001f\u007f-\u009f]/u.test(path)
+    ) {
+      return { kind, path };
+    }
+    return null;
+  }
+  if (values.length !== 1) return null;
   if (kind === "ready" && (value === "bash" || value === "zsh")) {
     return { kind, shell: value };
   }
@@ -132,7 +142,8 @@ function bashHistoryCleanup(safeNonce: string) {
 
 export function buildShellIntegrationInstallCommand(nonce: string) {
   const safeNonce = shellSingleQuote(nonce);
-  const bashMarker = `printf '\\033]${FINESHELL_OSC_ID};FineShell;%s;end;%s\\007' "$__fineshell_nonce" "$__fineshell_status"`;
+  const endMarker = `printf '\\033]${FINESHELL_OSC_ID};FineShell;%s;end;%s\\007' "$__fineshell_nonce" "$__fineshell_status"`;
+  const cwdMarker = `case "$PWD" in *[[:cntrl:]]*) ;; /*) printf '\\033]${FINESHELL_OSC_ID};FineShell;%s;cwd;%s\\007' "$__fineshell_nonce" "$PWD";; esac`;
   const readyMarker = (shell: string) =>
     `printf '\\r\\033[2K\\033]${FINESHELL_OSC_ID};FineShell;%s;ready;${shell}\\007' "$__fineshell_nonce"`;
   const unavailableMarker = `printf '\\r\\033[2K\\033]${FINESHELL_OSC_ID};FineShell;%s;unavailable;unsupported-shell\\007' ${safeNonce}`;
@@ -142,7 +153,7 @@ export function buildShellIntegrationInstallCommand(nonce: string) {
     `__fineshell_nonce=${safeNonce};`,
     "__fineshell_pc_was_set=${PROMPT_COMMAND+x};",
     "__fineshell_pc_decl=$(declare -p PROMPT_COMMAND 2>/dev/null || true);",
-    `__fineshell_prompt_command(){ __fineshell_status="$1"; ${bashMarker}; return "$__fineshell_status"; };`,
+    `__fineshell_prompt_command(){ __fineshell_status="$1"; ${endMarker}; ${cwdMarker}; return "$__fineshell_status"; };`,
     "if declare -p PROMPT_COMMAND 2>/dev/null | grep -q 'declare -a'; then PROMPT_COMMAND=('__fineshell_prompt_command \"$?\"' \"${PROMPT_COMMAND[@]}\"); else PROMPT_COMMAND='__fineshell_prompt_command \"$?\"; '" +
       '"${PROMPT_COMMAND-}"; fi;',
     bashHistoryCleanup(safeNonce),
@@ -150,7 +161,7 @@ export function buildShellIntegrationInstallCommand(nonce: string) {
     'elif [ -n "${ZSH_VERSION-}" ]; then',
     `__fineshell_nonce=${safeNonce};`,
     "autoload -Uz add-zsh-hook;",
-    `__fineshell_precmd(){ local __fineshell_status=$?; ${bashMarker}; return "$__fineshell_status"; };`,
+    `__fineshell_precmd(){ local __fineshell_status=$?; ${endMarker}; ${cwdMarker}; return "$__fineshell_status"; };`,
     "add-zsh-hook -d precmd __fineshell_precmd 2>/dev/null || true;",
     "add-zsh-hook precmd __fineshell_precmd;",
     `${readyMarker("zsh")};`,

--- a/src/tauri-protocol.test.ts
+++ b/src/tauri-protocol.test.ts
@@ -16,7 +16,7 @@ describe("Tauri shared protocol", () => {
     expect(PROTOCOL_VERSION).toBe(contract.version);
     expect(contract.commands[command]).toBe(true);
     expect(contract.events[event]).toBe(true);
-    expect(Object.keys(contract.commands)).toHaveLength(70);
+    expect(Object.keys(contract.commands)).toHaveLength(71);
     expect(Object.keys(contract.events)).toHaveLength(10);
   });
 


### PR DESCRIPTION
## 变更内容

- 修复 Shell Integration 安装命令回显，并默认启用命令生命周期上报
- 使用 Shell Integration 同步终端当前目录到 SFTP 文件管理器
- 支持从 Finder 或资源管理器拖拽本地文件和目录上传
- 支持递归扫描目录、创建空目录并保留相对路径
- 修复 macOS Retina 环境的原生拖放坐标判断
- 将多文件上传纳入同一批次，只在批次结束后提示并刷新一次
- 优化主机分组选择与相关操作按钮样式

## 影响

构建产物目录等包含大量小文件的项目可直接拖入 SFTP 面板，不再逐文件弹出完成提示或重复刷新文件列表。终端切换目录时，文件管理器会自动跟随当前远程目录。

## 验证

- `bun test`：301 项通过
- `bun run build`：通过
- `cargo test --lib`：84 项通过，8 项在线环境测试跳过
- `cargo clippy --all-targets --all-features -- -D warnings`：通过
