### PR TITLE
优化全局文本选择与 AI 侧栏交互

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,34 @@ body,
   margin: 0;
 }
 
+body,
+body * {
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+
+input,
+textarea,
+[contenteditable="true"],
+[role="textbox"],
+pre,
+pre *,
+code,
+code *,
+.application-error-content,
+.application-error-content *,
+.fingerprint-value,
+.fingerprint-value *,
+.ai-message-content,
+.ai-message-content *,
+.ai-file-edit-diff,
+.ai-file-edit-diff *,
+.release-notes-markdown,
+.release-notes-markdown * {
+  -webkit-user-select: text !important;
+  user-select: text !important;
+}
+
 .application-error {
   width: 100%;
   height: 100%;
@@ -3854,7 +3882,6 @@ body.sftp-remote-dragging * {
 
 .host-table-host-row {
   cursor: pointer;
-  user-select: none;
 }
 
 .host-tree-table tbody > .arco-table-tr:last-child > .arco-table-td,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ import {
   Typography,
 } from "@arco-design/web-react";
 import { isTauri } from "@tauri-apps/api/core";
-import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import {
   IconClose,
   IconCloseCircle,
@@ -67,9 +66,9 @@ import {
 } from "./ai-handoff";
 import {
   AI_SIDEBAR_DEFAULT_WIDTH,
-  aiWindowTargetWidth,
   clampAiSidebarWidth,
 } from "./ai-sidebar";
+import { useAiSidebarController } from "./hooks/useAiSidebarController";
 import {
   applicationUpdater,
   checkForApplicationUpdateOnStartup,
@@ -308,15 +307,11 @@ function App() {
   const [quickCommands, setQuickCommands] = useState<QuickCommandRecord[]>([]);
   const [quickCommandDrawerVisible, setQuickCommandDrawerVisible] =
     useState(false);
-  const [aiAssistantVisible, setAiAssistantVisible] = useState(false);
   const [serverMonitorCollapsed, setServerMonitorCollapsed] = useState(false);
   const [sftpCollapsed, setSftpCollapsed] = useState(false);
   const [aiSidebarWidth, setAiSidebarWidth] = useState(
     AI_SIDEBAR_DEFAULT_WIDTH,
   );
-  const [mainWorkspaceFrozenWidth, setMainWorkspaceFrozenWidth] = useState<
-    number | null
-  >(null);
   const [aiInitialPrompt, setAiInitialPrompt] = useState("");
   const [aiInitialContextIds, setAiInitialContextIds] = useState<
     AiContextSourceId[]
@@ -352,10 +347,6 @@ function App() {
     Record<string, number>
   >({});
   const [terminalFocusRequest, setTerminalFocusRequest] = useState(0);
-  const aiWindowShouldExpandRef = useRef(false);
-  const aiWindowExpandedRef = useRef(false);
-  const aiWindowExpansionRef = useRef(0);
-  const aiWindowResizeQueueRef = useRef<Promise<void>>(Promise.resolve());
   const mainSplitRef = useRef<HTMLElement | null>(null);
   const serverMonitorWidthRef = useRef("220px");
   const rightPanelRatiosRef = useRef({ terminal: 0.64, sftp: 0.36 });
@@ -365,6 +356,45 @@ function App() {
   );
   const manualReconnectsRef = useRef(new Set<string>());
   const intentionallyDisconnectedRef = useRef(new Set<string>());
+  const {
+    active: aiAssistantActive,
+    close: closeAiSidebar,
+    frozenWorkspaceWidth: mainWorkspaceFrozenWidth,
+    open: openAiSidebar,
+    phase: aiSidebarPhase,
+    toggle: toggleAiSidebar,
+    visible: aiAssistantVisible,
+  } = useAiSidebarController({
+    getWorkspaceWidth: () =>
+      mainSplitRef.current?.getBoundingClientRect().width,
+    onResizeFailure: (error, operation) => {
+      recordDiagnostic(
+        "warn",
+        "application.window",
+        operation === "expand"
+          ? "AI 侧栏窗口扩宽失败"
+          : "AI 侧栏窗口还原失败",
+        { error: commandErrorMessage(error) },
+      );
+      Message.warning(
+        operation === "expand"
+          ? "窗口无法扩宽，AI 助手已在当前窗口内打开"
+          : "窗口尺寸无法自动还原，请手动调整",
+      );
+    },
+    sidebarWidth: aiSidebarWidth,
+  });
+  const previousAiSidebarPhaseRef = useRef(aiSidebarPhase);
+
+  useEffect(() => {
+    if (
+      aiSidebarPhase === "closed" &&
+      previousAiSidebarPhaseRef.current !== "closed"
+    ) {
+      setTerminalFocusRequest((current) => current + 1);
+    }
+    previousAiSidebarPhaseRef.current = aiSidebarPhase;
+  }, [aiSidebarPhase]);
 
   const updateSession = useCallback(
     (sessionId: string, values: Partial<TerminalSession>) => {
@@ -1088,27 +1118,7 @@ function App() {
     setAiInitialPrompt(prompt);
     setAiInitialContextIds(contextIds);
     setAiInitialPromptRequest((current) => current + 1);
-    if (aiWindowShouldExpandRef.current) return;
-
-    aiWindowShouldExpandRef.current = true;
-    if (!isTauri()) {
-      setAiAssistantVisible(true);
-      return;
-    }
-
-    const currentMainWidth =
-      mainSplitRef.current?.getBoundingClientRect().width;
-    if (currentMainWidth) {
-      setMainWorkspaceFrozenWidth(currentMainWidth);
-      await new Promise<void>((resolve) =>
-        requestAnimationFrame(() => resolve()),
-      );
-    }
-    await synchronizeAiWindowWidth();
-    if (aiWindowShouldExpandRef.current) {
-      setAiAssistantVisible(true);
-      setMainWorkspaceFrozenWidth(null);
-    }
+    await openAiSidebar();
   }
 
   async function handoffToAi(sessionId: string, request: AiHandoffRequest) {
@@ -1129,81 +1139,16 @@ function App() {
     await openAiAssistant(request.prompt, [request.source.id]);
   }
 
-  async function closeAiAssistant() {
-    if (!aiWindowShouldExpandRef.current && !aiAssistantVisible) return;
-    aiWindowShouldExpandRef.current = false;
-    if (!isTauri()) {
-      setAiAssistantVisible(false);
-      setTerminalFocusRequest((current) => current + 1);
-      return;
-    }
-
-    const currentMainWidth =
-      mainSplitRef.current?.getBoundingClientRect().width;
-    if (currentMainWidth) setMainWorkspaceFrozenWidth(currentMainWidth);
-    setAiAssistantVisible(false);
-    if (currentMainWidth) {
-      await new Promise<void>((resolve) =>
-        requestAnimationFrame(() => resolve()),
-      );
-    }
-    await synchronizeAiWindowWidth();
-    if (!aiWindowShouldExpandRef.current) setMainWorkspaceFrozenWidth(null);
-    setTerminalFocusRequest((current) => current + 1);
+  function closeAiAssistant() {
+    closeAiSidebar();
   }
 
   function toggleAiAssistant() {
-    if (aiWindowShouldExpandRef.current || aiAssistantVisible) {
-      void closeAiAssistant();
-    } else {
-      void openAiAssistant();
+    if (!activeSession) {
+      Message.warning("请先打开终端会话");
+      return;
     }
-  }
-
-  function synchronizeAiWindowWidth() {
-    if (!isTauri()) return Promise.resolve();
-    aiWindowResizeQueueRef.current = aiWindowResizeQueueRef.current
-      .catch(() => undefined)
-      .then(async () => {
-        const shouldExpand = aiWindowShouldExpandRef.current;
-        const expanded = aiWindowExpandedRef.current;
-        const appliedExpansion = aiWindowExpansionRef.current;
-        if (shouldExpand === expanded) return;
-
-        const appWindow = getCurrentWindow();
-        const scaleFactor = await appWindow.scaleFactor();
-        const before = (await appWindow.innerSize()).toLogical(scaleFactor);
-        const targetWidth = aiWindowTargetWidth(
-          before.width,
-          shouldExpand,
-          appliedExpansion,
-        );
-        await appWindow.setSize(new LogicalSize(targetWidth, before.height));
-
-        if (shouldExpand) {
-          aiWindowExpandedRef.current = true;
-          aiWindowExpansionRef.current = AI_SIDEBAR_DEFAULT_WIDTH;
-          const after = (await appWindow.innerSize()).toLogical(scaleFactor);
-          aiWindowExpansionRef.current = Math.max(
-            0,
-            after.width - before.width,
-          );
-        } else {
-          aiWindowExpandedRef.current = false;
-          aiWindowExpansionRef.current = 0;
-        }
-      })
-      .catch((error) => {
-        recordDiagnostic(
-          "warn",
-          "application.window",
-          "AI 侧栏窗口尺寸调整失败",
-          {
-            error: commandErrorMessage(error),
-          },
-        );
-      });
-    return aiWindowResizeQueueRef.current;
+    toggleAiSidebar();
   }
 
   function disconnectSession(sessionId: string) {
@@ -1368,7 +1313,7 @@ function App() {
     <section className="panel terminal-panel">
       <SessionTabs
         activeSessionId={activeSessionId}
-        aiAssistantVisible={aiAssistantVisible}
+        aiAssistantVisible={aiAssistantActive}
         homeContent={
           <HostManagerPanel onConnect={openSession} settings={settings} />
         }

--- a/src/ai-sidebar.test.ts
+++ b/src/ai-sidebar.test.ts
@@ -7,7 +7,11 @@ import {
 
 describe("AI sidebar layout", () => {
   test("opens by adding the default sidebar width and restores it once", () => {
-    const expanded = aiWindowTargetWidth(1_280, true, 0);
+    const expanded = aiWindowTargetWidth(
+      1_280,
+      true,
+      AI_SIDEBAR_DEFAULT_WIDTH,
+    );
     expect(expanded).toBe(1_280 + AI_SIDEBAR_DEFAULT_WIDTH);
     expect(
       aiWindowTargetWidth(expanded, false, AI_SIDEBAR_DEFAULT_WIDTH),

--- a/src/ai-sidebar.ts
+++ b/src/ai-sidebar.ts
@@ -20,9 +20,9 @@ export function clampAiSidebarWidth(
 export function aiWindowTargetWidth(
   currentWidth: number,
   shouldExpand: boolean,
-  appliedExpansion: number,
+  expansion: number,
 ) {
   return shouldExpand
-    ? currentWidth + AI_SIDEBAR_DEFAULT_WIDTH
-    : Math.max(MAIN_WINDOW_MIN_WIDTH, currentWidth - appliedExpansion);
+    ? currentWidth + expansion
+    : Math.max(MAIN_WINDOW_MIN_WIDTH, currentWidth - expansion);
 }

--- a/src/components/AiAssistantPanel.tsx
+++ b/src/components/AiAssistantPanel.tsx
@@ -873,6 +873,12 @@ function AiAssistantPanel({
     return () => cancelAnimationFrame(frame);
   }, [messages, visible]);
 
+  useEffect(() => {
+    if (visible) return;
+    closeHistory();
+    closeFileChangeReview();
+  }, [fileEditApplying, visible]);
+
   const sendConversationMessage = (
     value: string,
     history: AiConversation["messages"] = messages,
@@ -974,8 +980,6 @@ function AiAssistantPanel({
   };
 
   const closePanel = () => {
-    if (sending) void cancelRequest();
-    closeHistory();
     onClose();
   };
 

--- a/src/hooks/useAiSidebarController.test.tsx
+++ b/src/hooks/useAiSidebarController.test.tsx
@@ -1,0 +1,213 @@
+import { describe, expect, mock, test } from "bun:test";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  useAiSidebarController,
+  type AiSidebarWindowAdapter,
+} from "./useAiSidebarController";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createWindowAdapter(options?: {
+  fullscreen?: boolean;
+  maximized?: boolean;
+  setSizeError?: Error;
+  width?: number;
+}) {
+  let width = options?.width ?? 1_200;
+  let height = 800;
+  let fullscreen = options?.fullscreen ?? false;
+  let maximized = options?.maximized ?? false;
+  let resizeListener: (() => void) | undefined;
+  const sizeRequests: Array<{ height: number; width: number }> = [];
+  const adapter: AiSidebarWindowAdapter = {
+    getInnerSize: async () => ({ height, width }),
+    isFullscreen: async () => fullscreen,
+    isMaximized: async () => maximized,
+    onResized: async (listener) => {
+      resizeListener = listener;
+      return () => {
+        resizeListener = undefined;
+      };
+    },
+    setInnerSize: async (nextWidth, nextHeight) => {
+      if (options?.setSizeError) throw options.setSizeError;
+      sizeRequests.push({ height: nextHeight, width: nextWidth });
+      width = nextWidth;
+      height = nextHeight;
+    },
+  };
+  return {
+    adapter,
+    currentWidth: () => width,
+    emitResize: () => resizeListener?.(),
+    setFullscreen: (value: boolean) => {
+      fullscreen = value;
+    },
+    setMaximized: (value: boolean) => {
+      maximized = value;
+    },
+    sizeRequests,
+  };
+}
+
+function renderController(
+  adapter: AiSidebarWindowAdapter,
+  options?: {
+    onResizeFailure?: (error: unknown, operation: string) => void;
+    sidebarWidth?: number;
+  },
+) {
+  return renderHook(() =>
+    useAiSidebarController({
+      getWorkspaceWidth: () => 1_200,
+      onResizeFailure: options?.onResizeFailure,
+      sidebarWidth: options?.sidebarWidth ?? 440,
+      windowAdapter: adapter,
+    }),
+  );
+}
+
+describe("useAiSidebarController", () => {
+  test("expands by the current sidebar width and restores the window", async () => {
+    const window = createWindowAdapter();
+    const view = renderController(window.adapter, { sidebarWidth: 520 });
+
+    act(() => {
+      void view.result.current.open();
+    });
+    expect(view.result.current.phase).toBe("opening");
+    expect(view.result.current.active).toBe(true);
+    expect(view.result.current.visible).toBe(false);
+    await waitFor(() => expect(view.result.current.phase).toBe("open"));
+    expect(window.currentWidth()).toBe(1_720);
+    expect(view.result.current.visible).toBe(true);
+
+    act(() => {
+      void view.result.current.close();
+    });
+    expect(view.result.current.phase).toBe("closing");
+    expect(view.result.current.visible).toBe(false);
+    await waitFor(() => expect(view.result.current.phase).toBe("closed"));
+    expect(window.currentWidth()).toBe(1_200);
+  });
+
+  test("serializes a close request made while expansion is running", async () => {
+    const gate = deferred();
+    const window = createWindowAdapter();
+    const originalSetSize = window.adapter.setInnerSize;
+    let firstResize = true;
+    window.adapter.setInnerSize = async (width, height) => {
+      if (firstResize) {
+        firstResize = false;
+        await gate.promise;
+      }
+      await originalSetSize(width, height);
+    };
+    const view = renderController(window.adapter);
+
+    act(() => {
+      void view.result.current.open();
+    });
+    await waitFor(() => expect(firstResize).toBe(false));
+    act(() => {
+      void view.result.current.close();
+    });
+    expect(view.result.current.phase).toBe("closing");
+    gate.resolve();
+
+    await waitFor(() => expect(view.result.current.phase).toBe("closed"));
+    expect(window.currentWidth()).toBe(1_200);
+    expect(window.sizeRequests.map((request) => request.width)).toEqual([
+      1_640, 1_200,
+    ]);
+  });
+
+  test("reopens cleanly while a collapse is still running", async () => {
+    const gate = deferred();
+    const window = createWindowAdapter();
+    const originalSetSize = window.adapter.setInnerSize;
+    let resizeCount = 0;
+    window.adapter.setInnerSize = async (width, height) => {
+      resizeCount += 1;
+      if (resizeCount === 2) await gate.promise;
+      await originalSetSize(width, height);
+    };
+    const view = renderController(window.adapter);
+
+    act(() => {
+      void view.result.current.open();
+    });
+    await waitFor(() => expect(view.result.current.phase).toBe("open"));
+    act(() => {
+      void view.result.current.close();
+    });
+    await waitFor(() => expect(resizeCount).toBe(2));
+    act(() => {
+      void view.result.current.open();
+    });
+    expect(view.result.current.phase).toBe("opening");
+    gate.resolve();
+
+    await waitFor(() => expect(view.result.current.phase).toBe("open"));
+    expect(window.currentWidth()).toBe(1_640);
+    expect(window.sizeRequests.map((request) => request.width)).toEqual([
+      1_640, 1_200, 1_640,
+    ]);
+  });
+
+  test("opens inside maximized windows without changing native size", async () => {
+    const window = createWindowAdapter({ maximized: true });
+    const view = renderController(window.adapter);
+
+    act(() => {
+      void view.result.current.open();
+    });
+    await waitFor(() => expect(view.result.current.phase).toBe("open"));
+
+    expect(window.sizeRequests).toHaveLength(0);
+    expect(view.result.current.visible).toBe(true);
+  });
+
+  test("falls back to the current window when expansion fails", async () => {
+    const onResizeFailure = mock((_error: unknown, _operation: string) => {});
+    const window = createWindowAdapter({
+      setSizeError: new Error("resize rejected"),
+    });
+    const view = renderController(window.adapter, { onResizeFailure });
+
+    act(() => {
+      void view.result.current.open();
+    });
+    await waitFor(() => expect(view.result.current.phase).toBe("open"));
+
+    expect(view.result.current.visible).toBe(true);
+    expect(onResizeFailure).toHaveBeenCalledTimes(1);
+    expect(onResizeFailure.mock.calls[0]?.[1]).toBe("expand");
+  });
+
+  test("defers restoring an expanded window until fullscreen ends", async () => {
+    const window = createWindowAdapter();
+    const view = renderController(window.adapter);
+
+    act(() => {
+      void view.result.current.open();
+    });
+    await waitFor(() => expect(view.result.current.phase).toBe("open"));
+    window.setFullscreen(true);
+    act(() => {
+      void view.result.current.close();
+    });
+    await waitFor(() => expect(view.result.current.phase).toBe("closed"));
+    expect(window.currentWidth()).toBe(1_640);
+
+    window.setFullscreen(false);
+    window.emitResize();
+    await waitFor(() => expect(window.currentWidth()).toBe(1_200));
+  });
+});

--- a/src/hooks/useAiSidebarController.ts
+++ b/src/hooks/useAiSidebarController.ts
@@ -1,0 +1,267 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { aiWindowTargetWidth } from "../ai-sidebar";
+
+export type AiSidebarPhase = "closed" | "opening" | "open" | "closing";
+
+export interface AiSidebarWindowAdapter {
+  getInnerSize: () => Promise<{ height: number; width: number }>;
+  isFullscreen: () => Promise<boolean>;
+  isMaximized: () => Promise<boolean>;
+  onResized?: (callback: () => void) => Promise<() => void>;
+  setInnerSize: (width: number, height: number) => Promise<void>;
+}
+
+interface UseAiSidebarControllerOptions {
+  getWorkspaceWidth: () => number | undefined;
+  onResizeFailure?: (
+    error: unknown,
+    operation: "expand" | "collapse",
+  ) => void;
+  sidebarWidth: number;
+  windowAdapter?: AiSidebarWindowAdapter | null;
+}
+
+interface AiSidebarControllerState {
+  frozenWorkspaceWidth: number | null;
+  phase: AiSidebarPhase;
+}
+
+function createWindowAdapter(): AiSidebarWindowAdapter | null {
+  if (!isTauri()) return null;
+  const appWindow = getCurrentWindow();
+  return {
+    getInnerSize: async () => {
+      const scaleFactor = await appWindow.scaleFactor();
+      const size = (await appWindow.innerSize()).toLogical(scaleFactor);
+      return { height: size.height, width: size.width };
+    },
+    isFullscreen: () => appWindow.isFullscreen(),
+    isMaximized: () => appWindow.isMaximized(),
+    onResized: (callback) => appWindow.onResized(callback),
+    setInnerSize: (width, height) =>
+      appWindow.setSize(new LogicalSize(width, height)),
+  };
+}
+
+export function useAiSidebarController({
+  getWorkspaceWidth,
+  onResizeFailure,
+  sidebarWidth,
+  windowAdapter,
+}: UseAiSidebarControllerOptions) {
+  const [state, setState] = useState<AiSidebarControllerState>({
+    frozenWorkspaceWidth: null,
+    phase: "closed",
+  });
+  const stateRef = useRef(state);
+  const sidebarWidthRef = useRef(sidebarWidth);
+  const getWorkspaceWidthRef = useRef(getWorkspaceWidth);
+  const onResizeFailureRef = useRef(onResizeFailure);
+  const adapterRef = useRef<AiSidebarWindowAdapter | null>();
+  const appliedExpansionRef = useRef(0);
+  const resizeFailureReportedRef = useRef(false);
+  const transitionQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+  if (adapterRef.current === undefined) {
+    adapterRef.current =
+      windowAdapter === undefined ? createWindowAdapter() : windowAdapter;
+  }
+  sidebarWidthRef.current = sidebarWidth;
+  getWorkspaceWidthRef.current = getWorkspaceWidth;
+  onResizeFailureRef.current = onResizeFailure;
+
+  const updateState = useCallback(
+    (update: Partial<AiSidebarControllerState>) => {
+      const next = { ...stateRef.current, ...update };
+      stateRef.current = next;
+      setState(next);
+    },
+    [],
+  );
+
+  const reportResizeFailure = useCallback(
+    (error: unknown, operation: "expand" | "collapse") => {
+      if (resizeFailureReportedRef.current) return;
+      resizeFailureReportedRef.current = true;
+      onResizeFailureRef.current?.(error, operation);
+    },
+    [],
+  );
+
+  const enqueue = useCallback((operation: () => Promise<void>) => {
+    transitionQueueRef.current = transitionQueueRef.current
+      .catch(() => undefined)
+      .then(operation);
+    return transitionQueueRef.current;
+  }, []);
+
+  const windowCanResize = useCallback(
+    async (adapter: AiSidebarWindowAdapter) => {
+      const [maximized, fullscreen] = await Promise.all([
+        adapter.isMaximized(),
+        adapter.isFullscreen(),
+      ]);
+      return !maximized && !fullscreen;
+    },
+    [],
+  );
+
+  const open = useCallback(() => {
+    const currentPhase = stateRef.current.phase;
+    if (currentPhase === "open" || currentPhase === "opening") {
+      return transitionQueueRef.current;
+    }
+
+    const adapter = adapterRef.current;
+    if (!adapter) {
+      updateState({ frozenWorkspaceWidth: null, phase: "open" });
+      return Promise.resolve();
+    }
+
+    updateState({
+      frozenWorkspaceWidth: getWorkspaceWidthRef.current() ?? null,
+      phase: "opening",
+    });
+
+    return enqueue(async () => {
+      if (stateRef.current.phase !== "opening") return;
+      try {
+        if (
+          appliedExpansionRef.current === 0 &&
+          (await windowCanResize(adapter))
+        ) {
+          if (stateRef.current.phase !== "opening") return;
+          const before = await adapter.getInnerSize();
+          const targetWidth = aiWindowTargetWidth(
+            before.width,
+            true,
+            sidebarWidthRef.current,
+          );
+          await adapter.setInnerSize(targetWidth, before.height);
+          appliedExpansionRef.current = Math.max(
+            0,
+            targetWidth - before.width,
+          );
+          const after = await adapter.getInnerSize();
+          appliedExpansionRef.current = Math.max(
+            0,
+            after.width - before.width,
+          );
+          resizeFailureReportedRef.current = false;
+        }
+      } catch (error) {
+        reportResizeFailure(error, "expand");
+      }
+
+      if (stateRef.current.phase === "opening") {
+        updateState({ frozenWorkspaceWidth: null, phase: "open" });
+      }
+    });
+  }, [enqueue, reportResizeFailure, updateState, windowCanResize]);
+
+  const collapseWindow = useCallback(
+    async (adapter: AiSidebarWindowAdapter) => {
+      const expansion = appliedExpansionRef.current;
+      if (expansion <= 0 || !(await windowCanResize(adapter))) return false;
+      const before = await adapter.getInnerSize();
+      await adapter.setInnerSize(
+        aiWindowTargetWidth(before.width, false, expansion),
+        before.height,
+      );
+      appliedExpansionRef.current = 0;
+      resizeFailureReportedRef.current = false;
+      return true;
+    },
+    [windowCanResize],
+  );
+
+  const close = useCallback(() => {
+    const currentPhase = stateRef.current.phase;
+    if (currentPhase === "closed" || currentPhase === "closing") {
+      return transitionQueueRef.current;
+    }
+
+    const adapter = adapterRef.current;
+    if (!adapter) {
+      updateState({ frozenWorkspaceWidth: null, phase: "closed" });
+      return Promise.resolve();
+    }
+
+    updateState({
+      frozenWorkspaceWidth: getWorkspaceWidthRef.current() ?? null,
+      phase: "closing",
+    });
+
+    return enqueue(async () => {
+      if (stateRef.current.phase !== "closing") return;
+      try {
+        await collapseWindow(adapter);
+      } catch (error) {
+        reportResizeFailure(error, "collapse");
+      }
+      if (stateRef.current.phase === "closing") {
+        updateState({ frozenWorkspaceWidth: null, phase: "closed" });
+      }
+    });
+  }, [collapseWindow, enqueue, reportResizeFailure, updateState]);
+
+  const toggle = useCallback(() => {
+    if (["open", "opening"].includes(stateRef.current.phase)) return close();
+    return open();
+  }, [close, open]);
+
+  useEffect(() => {
+    const adapter = adapterRef.current;
+    if (!adapter?.onResized) return;
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    let timer: number | undefined;
+    void adapter.onResized(() => {
+      if (
+        disposed ||
+        stateRef.current.phase !== "closed" ||
+        appliedExpansionRef.current <= 0
+      ) {
+        return;
+      }
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        void enqueue(async () => {
+          if (
+            disposed ||
+            stateRef.current.phase !== "closed" ||
+            appliedExpansionRef.current <= 0
+          ) {
+            return;
+          }
+          try {
+            await collapseWindow(adapter);
+          } catch (error) {
+            reportResizeFailure(error, "collapse");
+          }
+        });
+      }, 120);
+    }).then((dispose) => {
+      if (disposed) dispose();
+      else unlisten = dispose;
+    });
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+      unlisten?.();
+    };
+  }, [collapseWindow, enqueue, reportResizeFailure]);
+
+  return {
+    active: state.phase === "open" || state.phase === "opening",
+    close,
+    frozenWorkspaceWidth: state.frozenWorkspaceWidth,
+    open,
+    phase: state.phase,
+    toggle,
+    transitioning: state.phase === "opening" || state.phase === "closing",
+    visible: state.phase === "open",
+  };
+}

--- a/src/select-all-shortcut.test.ts
+++ b/src/select-all-shortcut.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  handleDocumentSelectStart,
+  handleSelectAllShortcut,
   isEditableSelectAllTarget,
+  isSelectableTextTarget,
   requestContextSelectAll,
   SELECT_ALL_REQUEST_EVENT,
   selectEditableTarget,
@@ -41,5 +44,67 @@ describe("select all shortcuts", () => {
     expect(invert).toBe(true);
 
     window.removeEventListener(SELECT_ALL_REQUEST_EVENT, listener);
+  });
+
+  test("blocks document-wide select all outside editable controls", () => {
+    const content = document.createElement("div");
+    content.textContent = "FineShell workspace";
+    document.body.appendChild(content);
+
+    const range = document.createRange();
+    range.selectNodeContents(content);
+    window.getSelection()?.addRange(range);
+
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, "target", { value: content });
+
+    handleSelectAllShortcut(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.getSelection()?.rangeCount).toBe(0);
+    content.remove();
+  });
+
+  test("keeps native select all behavior inside text inputs", () => {
+    const input = document.createElement("input");
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, "target", { value: input });
+
+    handleSelectAllShortcut(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("blocks pointer text selection across regular interface content", () => {
+    const content = document.createElement("div");
+    const event = new Event("selectstart", { cancelable: true });
+    Object.defineProperty(event, "target", { value: content });
+
+    handleDocumentSelectStart(event);
+
+    expect(isSelectableTextTarget(content)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("allows pointer text selection in explicitly selectable content", () => {
+    const terminalText = document.createElement("span");
+    const terminal = document.createElement("div");
+    terminal.className = "xterm";
+    terminal.appendChild(terminalText);
+    const event = new Event("selectstart", { cancelable: true });
+    Object.defineProperty(event, "target", { value: terminalText });
+
+    handleDocumentSelectStart(event);
+
+    expect(isSelectableTextTarget(terminalText)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/src/select-all-shortcut.ts
+++ b/src/select-all-shortcut.ts
@@ -9,6 +9,7 @@ export interface SelectAllRequestDetail {
 
 function targetElement(target: EventTarget | null) {
   if (target instanceof Element) return target;
+  if (target instanceof Node) return target.parentElement;
   return null;
 }
 
@@ -24,6 +25,25 @@ const nonTextInputTypes = new Set([
   "reset",
   "submit",
 ]);
+
+const selectableTextSelector = [
+  "input",
+  "textarea",
+  '[contenteditable="true"]',
+  '[role="textbox"]',
+  "pre",
+  "code",
+  ".xterm",
+  ".application-error-content",
+  ".fingerprint-value",
+  ".ai-message-content",
+  ".ai-file-edit-diff",
+  ".release-notes-markdown",
+].join(", ");
+
+export function isSelectableTextTarget(target: EventTarget | null) {
+  return Boolean(targetElement(target)?.closest(selectableTextSelector));
+}
 
 export function isEditableSelectAllTarget(target: EventTarget | null) {
   const element = targetElement(target);
@@ -67,6 +87,10 @@ export function requestContextSelectAll(invert: boolean) {
   return event.defaultPrevented;
 }
 
+function clearDocumentSelection() {
+  window.getSelection()?.removeAllRanges();
+}
+
 function isSelectAllShortcut(event: KeyboardEvent) {
   return (
     (event.metaKey || event.ctrlKey) &&
@@ -75,25 +99,31 @@ function isSelectAllShortcut(event: KeyboardEvent) {
   );
 }
 
+export function handleSelectAllShortcut(event: KeyboardEvent) {
+  if (!isSelectAllShortcut(event)) return;
+  if (!event.shiftKey && isEditableSelectAllTarget(event.target)) return;
+
+  requestContextSelectAll(event.shiftKey);
+  clearDocumentSelection();
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}
+
+export function handleDocumentSelectStart(event: Event) {
+  if (isSelectableTextTarget(event.target)) return;
+  event.preventDefault();
+  clearDocumentSelection();
+}
+
 export function installSelectAllShortcuts() {
   if (isTauri()) {
     void listenProtocolEvent("menu-select-all", ({ payload }) => {
       if (requestContextSelectAll(payload.invert)) return;
-      if (!payload.invert) selectEditableTarget(document.activeElement);
+      if (!payload.invert && selectEditableTarget(document.activeElement)) return;
+      clearDocumentSelection();
     });
-    return;
   }
 
-  window.addEventListener(
-    "keydown",
-    (event) => {
-      if (!isSelectAllShortcut(event)) return;
-      if (!event.shiftKey && isEditableSelectAllTarget(event.target)) return;
-
-      requestContextSelectAll(event.shiftKey);
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    true,
-  );
+  window.addEventListener("keydown", handleSelectAllShortcut, true);
+  document.addEventListener("selectstart", handleDocumentSelectStart, true);
 }


### PR DESCRIPTION
## 变更

- 默认禁止应用界面文本选择，同时保留终端、输入框、代码、AI 内容等必要区域的选择能力
- 统一拦截 Command/Ctrl+A，避免误选整个页面，并保留文件管理快捷选择
- 将 AI 侧栏重构为明确的打开、关闭状态机，按实际侧栏宽度调整窗口
- 处理快速切换、最大化/全屏、窗口缩放失败以及关闭后的终端焦点恢复
- 关闭 AI 侧栏时同步收起历史记录与文件审查浮层，不中断正在执行的 AI 请求

## 验证

- `bun run check`
- 339 项测试通过
- TypeScript 检查及 Vite 生产构建通过