### PR TITLE
配置 Gitee 镜像与双源版本发布

### DIFF
--- a/.github/workflows/gitee-mirror.yml
+++ b/.github/workflows/gitee-mirror.yml
@@ -1,0 +1,45 @@
+name: Mirror to Gitee
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitee-mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Sync main and tags
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Gitee SSH access
+        shell: bash
+        env:
+          GITEE_KNOWN_HOSTS: ${{ secrets.GITEE_KNOWN_HOSTS }}
+          GITEE_SSH_PRIVATE_KEY: ${{ secrets.GITEE_SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$GITEE_SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "$GITEE_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/id_ed25519 ~/.ssh/known_hosts
+
+      - name: Sync GitHub main and tags to Gitee
+        shell: bash
+        run: |
+          git fetch origin main --tags --force
+          git remote add gitee git@gitee.com:Max0897/FineShell.git
+          git push gitee refs/remotes/origin/main:refs/heads/main
+          git push gitee --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -265,3 +265,116 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
         run: gh release edit "$RELEASE_TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --draft=false
+
+  sync-gitee-release:
+    name: Sync Gitee release
+    needs:
+      - validate
+      - publish
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - name: Validate Gitee release credentials
+        shell: bash
+        env:
+          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
+          GITEE_KNOWN_HOSTS: ${{ secrets.GITEE_KNOWN_HOSTS }}
+          GITEE_SSH_PRIVATE_KEY: ${{ secrets.GITEE_SSH_PRIVATE_KEY }}
+        run: |
+          test -n "$GITEE_ACCESS_TOKEN" || {
+            echo "GITEE_ACCESS_TOKEN is not configured." >&2
+            exit 1
+          }
+          test -n "$GITEE_KNOWN_HOSTS" || {
+            echo "GITEE_KNOWN_HOSTS is not configured." >&2
+            exit 1
+          }
+          test -n "$GITEE_SSH_PRIVATE_KEY" || {
+            echo "GITEE_SSH_PRIVATE_KEY is not configured." >&2
+            exit 1
+          }
+      - name: Configure Gitee SSH access
+        shell: bash
+        env:
+          GITEE_KNOWN_HOSTS: ${{ secrets.GITEE_KNOWN_HOSTS }}
+          GITEE_SSH_PRIVATE_KEY: ${{ secrets.GITEE_SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$GITEE_SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "$GITEE_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/id_ed25519 ~/.ssh/known_hosts
+      - name: Sync release tag to Gitee
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          git fetch origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG" --force
+          git remote add gitee git@gitee.com:Max0897/FineShell.git
+          git push gitee "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+      - name: Download GitHub release assets for Gitee
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/gitee-assets" "$RUNNER_TEMP/gitee-updater"
+          gh release download "$RELEASE_TAG" --dir "$RUNNER_TEMP/gitee-assets"
+          bun scripts/extract-release-notes.ts "$RELEASE_TAG" \
+            > "$RUNNER_TEMP/release-notes.md"
+      - name: Publish Gitee release
+        shell: bash
+        env:
+          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          bun scripts/publish-gitee-release.ts \
+            "$RELEASE_TAG" \
+            "$GITHUB_SHA" \
+            "$RUNNER_TEMP/release-notes.md" \
+            "$RUNNER_TEMP/gitee-assets" \
+            "$RUNNER_TEMP/gitee-assets/latest.json" \
+            "$RUNNER_TEMP/gitee-updater/latest.json"
+      - name: Validate Gitee updater manifest
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          bun scripts/validate-updater-manifest.ts \
+            "$RUNNER_TEMP/gitee-updater/latest.json" \
+            "$RELEASE_TAG" \
+            gitee
+      - name: Publish latest Gitee updater manifest
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        run: |
+          ota_directory="$RUNNER_TEMP/gitee-ota"
+          if git ls-remote --exit-code --heads gitee refs/heads/ota >/dev/null 2>&1; then
+            git clone --depth 1 --branch ota --single-branch \
+              git@gitee.com:Max0897/FineShell.git "$ota_directory"
+          else
+            git -C "$ota_directory" init -b ota
+            git -C "$ota_directory" remote add gitee \
+              git@gitee.com:Max0897/FineShell.git
+          fi
+
+          install -m 644 "$RUNNER_TEMP/gitee-updater/latest.json" \
+            "$ota_directory/latest.json"
+          git -C "$ota_directory" config user.name "FineShell Release"
+          git -C "$ota_directory" config user.email "actions@github.com"
+          git -C "$ota_directory" add latest.json
+
+          if git -C "$ota_directory" diff --cached --quiet; then
+            echo "Gitee OTA manifest is already up to date."
+            exit 0
+          fi
+
+          git -C "$ota_directory" commit -m "发布 $RELEASE_TAG 更新清单"
+          git -C "$ota_directory" push gitee HEAD:refs/heads/ota

--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-版本标签会触发 GitHub Actions 构建 macOS、Linux 和 Windows 安装包；所有平台构建成功后，工作流会将 `CHANGELOG.md` 中对应版本的内容写入 Release，随后才会公开发布。
+版本标签会触发 GitHub Actions 构建 macOS、Linux 和 Windows 安装包；所有平台构建成功后，工作流会将 `CHANGELOG.md` 中对应版本的内容写入 GitHub Release，随后同步相同的安装包、签名和发布说明到 Gitee Release。客户端优先使用 Gitee 更新清单，Gitee 不可用时自动回退到 GitHub。
+
+Gitee 发布同步需要在 GitHub 仓库中配置 `GITEE_ACCESS_TOKEN`、`GITEE_SSH_PRIVATE_KEY` 和 `GITEE_KNOWN_HOSTS` 三个 Secrets。
 
 ## 支持项目
 

--- a/scripts/publish-gitee-release.test.ts
+++ b/scripts/publish-gitee-release.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { createGiteeUpdaterManifest } from "./publish-gitee-release";
+
+const githubUrl =
+  "https://github.com/Max0897/fineshell/releases/download/v1.2.3/FineShell_1.2.3_windows_x64-setup.exe";
+const giteeUrl =
+  "https://gitee.com/api/v5/repos/Max0897/FineShell/releases/42/attach_files/7/download";
+
+describe("Gitee updater manifest", () => {
+  test("maps updater assets by their release file names", () => {
+    const result = createGiteeUpdaterManifest(
+      {
+        version: "1.2.3",
+        platforms: {
+          "windows-x86_64-nsis": {
+            signature: "signed",
+            url: githubUrl,
+          },
+        },
+      },
+      [
+        {
+          browser_download_url: giteeUrl,
+          id: 7,
+          name: "FineShell_1.2.3_windows_x64-setup.exe",
+          size: 1024,
+        },
+      ],
+    );
+
+    expect(result.normalizedKeys).toEqual(["windows-x86_64-nsis"]);
+    expect(result.manifest).toEqual({
+      version: "1.2.3",
+      platforms: {
+        "windows-x86_64-nsis": {
+          signature: "signed",
+          url: giteeUrl,
+        },
+      },
+    });
+  });
+
+  test("decodes escaped release file names", () => {
+    const result = createGiteeUpdaterManifest(
+      {
+        platforms: {
+          "darwin-aarch64": {
+            signature: "signed",
+            url: "https://github.com/example/releases/download/v1.2.3/FineShell%20Updater.tar.gz",
+          },
+        },
+      },
+      [
+        {
+          browser_download_url: giteeUrl,
+          id: 7,
+          name: "FineShell Updater.tar.gz",
+          size: 1024,
+        },
+      ],
+    );
+
+    expect(
+      (result.manifest.platforms as Record<string, { url: string }>)[
+        "darwin-aarch64"
+      ].url,
+    ).toBe(giteeUrl);
+  });
+
+  test("rejects missing and duplicate release attachments", () => {
+    expect(() =>
+      createGiteeUpdaterManifest(
+        {
+          platforms: {
+            "windows-x86_64": { signature: "signed", url: githubUrl },
+          },
+        },
+        [],
+      ),
+    ).toThrow("缺少更新附件");
+
+    const attachment = {
+      browser_download_url: giteeUrl,
+      id: 7,
+      name: "FineShell_1.2.3_windows_x64-setup.exe",
+      size: 1024,
+    };
+    expect(() =>
+      createGiteeUpdaterManifest({ platforms: {} }, [
+        attachment,
+        { ...attachment, id: 8 },
+      ]),
+    ).toThrow("存在重名附件");
+  });
+
+  test("rejects non-Gitee or insecure attachment URLs", () => {
+    expect(() =>
+      createGiteeUpdaterManifest({ platforms: {} }, [
+        {
+          browser_download_url: "https://example.com/file",
+          id: 7,
+          name: "file",
+          size: 1,
+        },
+      ]),
+    ).toThrow("必须使用 gitee.com HTTPS 地址");
+  });
+});

--- a/scripts/publish-gitee-release.ts
+++ b/scripts/publish-gitee-release.ts
@@ -1,0 +1,384 @@
+import { basename, resolve } from "node:path";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+
+interface GiteeAttachment {
+  browser_download_url: string;
+  id: number;
+  name: string;
+  size: number;
+}
+
+interface GiteeRelease {
+  id: number;
+}
+
+interface UpdaterPlatform {
+  url?: unknown;
+}
+
+interface UpdaterManifest {
+  platforms?: unknown;
+}
+
+interface GiteeUpdaterManifestResult {
+  manifest: Record<string, unknown>;
+  normalizedKeys: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJson(text: string, label: string) {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`${label}返回了无效 JSON`);
+  }
+}
+
+function parseRelease(value: unknown): GiteeRelease {
+  if (!isRecord(value) || !Number.isInteger(value.id)) {
+    throw new Error("Gitee Release 响应缺少有效 ID");
+  }
+  return { id: Number(value.id) };
+}
+
+function parseAttachment(value: unknown): GiteeAttachment {
+  if (
+    !isRecord(value) ||
+    !Number.isInteger(value.id) ||
+    typeof value.name !== "string" ||
+    !value.name ||
+    !Number.isInteger(value.size) ||
+    typeof value.browser_download_url !== "string"
+  ) {
+    throw new Error("Gitee Release 附件响应格式无效");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value.browser_download_url);
+  } catch {
+    throw new Error(`Gitee 附件 ${value.name} 的下载地址无效`);
+  }
+  if (url.protocol !== "https:" || url.hostname !== "gitee.com") {
+    throw new Error(`Gitee 附件 ${value.name} 必须使用 gitee.com HTTPS 地址`);
+  }
+
+  return {
+    browser_download_url: value.browser_download_url,
+    id: Number(value.id),
+    name: value.name,
+    size: Number(value.size),
+  };
+}
+
+function updaterAssetName(value: string) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("更新清单包含无效下载地址");
+  }
+  const name = decodeURIComponent(url.pathname.split("/").at(-1) ?? "");
+  if (!name) throw new Error("更新清单下载地址缺少文件名");
+  return name;
+}
+
+export function createGiteeUpdaterManifest(
+  value: unknown,
+  attachmentValues: unknown,
+): GiteeUpdaterManifestResult {
+  if (!isRecord(value)) throw new Error("更新清单格式无效");
+  const manifest = value as UpdaterManifest;
+  if (!isRecord(manifest.platforms)) {
+    throw new Error("更新清单缺少 platforms 对象");
+  }
+  if (!Array.isArray(attachmentValues)) {
+    throw new Error("Gitee Release 附件列表格式无效");
+  }
+
+  const attachments = attachmentValues.map(parseAttachment);
+  const attachmentUrls = new Map<string, string>();
+  attachments.forEach((attachment) => {
+    if (attachmentUrls.has(attachment.name)) {
+      throw new Error(`Gitee Release 存在重名附件：${attachment.name}`);
+    }
+    attachmentUrls.set(attachment.name, attachment.browser_download_url);
+  });
+
+  const platforms: Record<string, unknown> = {};
+  const normalizedKeys: string[] = [];
+  Object.entries(manifest.platforms).forEach(([key, value]) => {
+    if (!isRecord(value)) {
+      platforms[key] = value;
+      return;
+    }
+
+    const platform = value as UpdaterPlatform;
+    if (typeof platform.url !== "string") {
+      platforms[key] = value;
+      return;
+    }
+    const assetName = updaterAssetName(platform.url);
+    const downloadUrl = attachmentUrls.get(assetName);
+    if (!downloadUrl) {
+      throw new Error(`Gitee Release 缺少更新附件：${assetName}`);
+    }
+    platforms[key] = { ...value, url: downloadUrl };
+    normalizedKeys.push(key);
+  });
+
+  return {
+    manifest: { ...value, platforms },
+    normalizedKeys,
+  };
+}
+
+class GiteeReleaseClient {
+  private readonly apiBase: string;
+
+  constructor(
+    private readonly accessToken: string,
+    owner: string,
+    repository: string,
+  ) {
+    this.apiBase = `https://gitee.com/api/v5/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}`;
+  }
+
+  private authenticatedUrl(path: string) {
+    const url = new URL(`${this.apiBase}${path}`);
+    url.searchParams.set("access_token", this.accessToken);
+    return url;
+  }
+
+  private form(fields: Record<string, string>) {
+    const form = new FormData();
+    form.append("access_token", this.accessToken);
+    Object.entries(fields).forEach(([key, value]) => form.append(key, value));
+    return form;
+  }
+
+  private async responseJson(
+    response: Response,
+    expectedStatus: number,
+    label: string,
+  ) {
+    const text = await response.text();
+    if (response.status !== expectedStatus) {
+      throw new Error(
+        `${label}失败（HTTP ${response.status}）：${text.slice(0, 500)}`,
+      );
+    }
+    return parseJson(text, label);
+  }
+
+  async releaseByTag(tag: string) {
+    const response = await fetch(
+      this.authenticatedUrl(`/releases/tags/${encodeURIComponent(tag)}`),
+    );
+    if (response.status === 404) return null;
+    return parseRelease(
+      await this.responseJson(response, 200, "查询 Gitee Release"),
+    );
+  }
+
+  async createOrUpdateRelease(options: {
+    body: string;
+    name: string;
+    prerelease: boolean;
+    tag: string;
+    targetCommitish: string;
+  }) {
+    const existing = await this.releaseByTag(options.tag);
+    const fields = {
+      body: options.body,
+      name: options.name,
+      prerelease: String(options.prerelease),
+      tag_name: options.tag,
+    };
+    if (existing) {
+      const response = await fetch(`${this.apiBase}/releases/${existing.id}`, {
+        body: this.form(fields),
+        method: "PATCH",
+      });
+      return parseRelease(
+        await this.responseJson(response, 200, "更新 Gitee Release"),
+      );
+    }
+
+    const response = await fetch(`${this.apiBase}/releases`, {
+      body: this.form({
+        ...fields,
+        target_commitish: options.targetCommitish,
+      }),
+      method: "POST",
+    });
+    return parseRelease(
+      await this.responseJson(response, 201, "创建 Gitee Release"),
+    );
+  }
+
+  async attachments(releaseId: number) {
+    const response = await fetch(
+      this.authenticatedUrl(
+        `/releases/${releaseId}/attach_files?per_page=100&direction=asc`,
+      ),
+    );
+    const value = await this.responseJson(
+      response,
+      200,
+      "查询 Gitee Release 附件",
+    );
+    if (!Array.isArray(value)) {
+      throw new Error("Gitee Release 附件列表格式无效");
+    }
+    return value.map(parseAttachment);
+  }
+
+  async uploadAttachment(
+    releaseId: number,
+    path: string,
+    name = basename(path),
+  ) {
+    const form = new FormData();
+    form.append("access_token", this.accessToken);
+    form.append("file", Bun.file(path), name);
+    const response = await fetch(
+      `${this.apiBase}/releases/${releaseId}/attach_files`,
+      { body: form, method: "POST" },
+    );
+    return parseAttachment(
+      await this.responseJson(response, 201, `上传 Gitee 附件 ${name}`),
+    );
+  }
+}
+
+async function ensureAttachments(
+  client: GiteeReleaseClient,
+  releaseId: number,
+  assetsDirectory: string,
+) {
+  const existing = await client.attachments(releaseId);
+  const byName = new Map(
+    existing.map((attachment) => [attachment.name, attachment]),
+  );
+  const assetPaths = readdirSync(assetsDirectory)
+    .map((name) => resolve(assetsDirectory, name))
+    .filter(
+      (path) => statSync(path).isFile() && basename(path) !== "latest.json",
+    )
+    .sort((left, right) => basename(left).localeCompare(basename(right)));
+
+  for (const path of assetPaths) {
+    const name = basename(path);
+    const current = byName.get(name);
+    if (current) {
+      const localSize = statSync(path).size;
+      if (current.size !== localSize) {
+        throw new Error(
+          `Gitee Release 附件 ${name} 已存在但尺寸不同，拒绝覆盖不可变版本`,
+        );
+      }
+      continue;
+    }
+    const uploaded = await client.uploadAttachment(releaseId, path);
+    byName.set(uploaded.name, uploaded);
+  }
+  return [...byName.values()];
+}
+
+async function ensureLatestManifest(
+  client: GiteeReleaseClient,
+  releaseId: number,
+  path: string,
+  attachments: GiteeAttachment[],
+) {
+  const current = attachments.find(
+    (attachment) => attachment.name === "latest.json",
+  );
+  if (!current) return client.uploadAttachment(releaseId, path, "latest.json");
+
+  const response = await fetch(current.browser_download_url);
+  if (!response.ok) {
+    throw new Error(
+      `下载已有 Gitee latest.json 失败（HTTP ${response.status}）`,
+    );
+  }
+  const remote = await response.text();
+  const local = readFileSync(path, "utf8");
+  if (remote !== local) {
+    throw new Error("Gitee latest.json 已存在但内容不同，拒绝覆盖不可变版本");
+  }
+  return current;
+}
+
+async function publishGiteeRelease() {
+  const [
+    releaseTag,
+    targetCommitish,
+    releaseNotesPath,
+    assetsDirectory,
+    sourceManifestPath,
+    outputManifestPath,
+  ] = process.argv.slice(2);
+  if (
+    !releaseTag ||
+    !targetCommitish ||
+    !releaseNotesPath ||
+    !assetsDirectory ||
+    !sourceManifestPath ||
+    !outputManifestPath
+  ) {
+    throw new Error(
+      "用法：publish-gitee-release <tag> <commit> <notes> <assets-dir> <source-manifest> <output-manifest>",
+    );
+  }
+  if (
+    !/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(releaseTag)
+  ) {
+    throw new Error(`版本标签“${releaseTag}”格式无效`);
+  }
+
+  const accessToken = process.env.GITEE_ACCESS_TOKEN?.trim();
+  if (!accessToken) throw new Error("缺少 GITEE_ACCESS_TOKEN");
+  const owner = process.env.GITEE_OWNER?.trim() || "Max0897";
+  const repository = process.env.GITEE_REPOSITORY?.trim() || "FineShell";
+  const client = new GiteeReleaseClient(accessToken, owner, repository);
+  const release = await client.createOrUpdateRelease({
+    body: readFileSync(releaseNotesPath, "utf8"),
+    name: `FineShell ${releaseTag}`,
+    prerelease: releaseTag.includes("-"),
+    tag: releaseTag,
+    targetCommitish,
+  });
+  const attachments = await ensureAttachments(
+    client,
+    release.id,
+    resolve(assetsDirectory),
+  );
+  const sourceManifest = JSON.parse(readFileSync(sourceManifestPath, "utf8"));
+  const normalized = createGiteeUpdaterManifest(sourceManifest, attachments);
+  writeFileSync(
+    outputManifestPath,
+    `${JSON.stringify(normalized.manifest, null, 2)}\n`,
+    "utf8",
+  );
+  await ensureLatestManifest(
+    client,
+    release.id,
+    outputManifestPath,
+    attachments,
+  );
+  console.log(
+    `Gitee Release ${releaseTag} 已同步：${normalized.normalizedKeys.join(", ")}`,
+  );
+}
+
+if (import.meta.main) {
+  publishGiteeRelease().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/validate-updater-manifest.test.ts
+++ b/scripts/validate-updater-manifest.test.ts
@@ -6,6 +6,11 @@ const platform = {
   url: "https://github.com/example/app/releases/download/v1.2.3/app.tar.gz",
 };
 
+const giteePlatform = {
+  signature: "signed-update",
+  url: "https://gitee.com/api/v5/repos/example/app/releases/42/attach_files/7/download",
+};
+
 function manifest(platforms: Record<string, unknown>) {
   return { platforms, version: "1.2.3" };
 }
@@ -101,9 +106,9 @@ describe("updater manifest validation", () => {
       ),
     ).toThrow("缺少签名");
 
-    expect(() =>
-      validateUpdaterManifest(manifest({}), "v1.2.4"),
-    ).toThrow("版本不一致");
+    expect(() => validateUpdaterManifest(manifest({}), "v1.2.4")).toThrow(
+      "版本不一致",
+    );
   });
 
   test("requires HTTPS download URLs", () => {
@@ -143,5 +148,34 @@ describe("updater manifest validation", () => {
         "v1.2.3",
       ),
     ).toThrow("必须使用当前版本的 GitHub Release 公开下载地址");
+  });
+
+  test("accepts a complete Gitee release manifest", () => {
+    expect(
+      validateUpdaterManifest(
+        manifest({
+          "darwin-aarch64-app": giteePlatform,
+          "darwin-x86_64": giteePlatform,
+          "linux-x86_64-deb": giteePlatform,
+          "linux-aarch64-deb": giteePlatform,
+          "windows-x86_64-nsis": giteePlatform,
+          "windows-aarch64-nsis": giteePlatform,
+        }),
+        "v1.2.3",
+        "gitee",
+      ),
+    ).toHaveLength(6);
+  });
+
+  test("rejects non-Gitee URLs in Gitee manifests", () => {
+    expect(() =>
+      validateUpdaterManifest(
+        manifest({
+          "darwin-aarch64-app": platform,
+        }),
+        "v1.2.3",
+        "gitee",
+      ),
+    ).toThrow("必须使用 Gitee Release 公开下载地址");
   });
 });

--- a/scripts/validate-updater-manifest.ts
+++ b/scripts/validate-updater-manifest.ts
@@ -10,6 +10,8 @@ interface UpdaterManifest {
   version?: unknown;
 }
 
+export type UpdaterDistribution = "gitee" | "github";
+
 const REQUIRED_PLATFORM_GROUPS = [
   {
     keys: ["darwin-aarch64-app", "darwin-aarch64"],
@@ -28,11 +30,7 @@ const REQUIRED_PLATFORM_GROUPS = [
     label: "Linux ARM64",
   },
   {
-    keys: [
-      "windows-x86_64-nsis",
-      "windows-x86_64-msi",
-      "windows-x86_64",
-    ],
+    keys: ["windows-x86_64-nsis", "windows-x86_64-msi", "windows-x86_64"],
     label: "Windows x64",
   },
   {
@@ -46,13 +44,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function expectedVersionFromTag(releaseTag: string) {
-  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(releaseTag)) {
+  if (
+    !/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(releaseTag)
+  ) {
     throw new Error(`版本标签“${releaseTag}”格式无效`);
   }
   return releaseTag.slice(1);
 }
 
-function validatePlatform(key: string, value: unknown, releaseTag: string) {
+function validatePlatform(
+  key: string,
+  value: unknown,
+  releaseTag: string,
+  distribution: UpdaterDistribution,
+) {
   if (!isRecord(value)) {
     throw new Error(`更新清单平台 ${key} 格式无效`);
   }
@@ -74,6 +79,15 @@ function validatePlatform(key: string, value: unknown, releaseTag: string) {
   if (url.protocol !== "https:") {
     throw new Error(`更新清单平台 ${key} 的下载地址必须使用 HTTPS`);
   }
+  if (distribution === "gitee") {
+    if (url.hostname !== "gitee.com") {
+      throw new Error(
+        `更新清单平台 ${key} 必须使用 Gitee Release 公开下载地址`,
+      );
+    }
+    return;
+  }
+
   const match = url.pathname.match(
     /^\/[^/]+\/[^/]+\/releases\/download\/([^/]+)\/[^/]+$/,
   );
@@ -87,6 +101,7 @@ function validatePlatform(key: string, value: unknown, releaseTag: string) {
 export function validateUpdaterManifest(
   value: unknown,
   releaseTag: string,
+  distribution: UpdaterDistribution = "github",
 ) {
   if (!isRecord(value)) throw new Error("更新清单格式无效");
 
@@ -100,13 +115,14 @@ export function validateUpdaterManifest(
   if (!isRecord(manifest.platforms)) {
     throw new Error("更新清单缺少 platforms 对象");
   }
+  const platforms = manifest.platforms;
 
-  Object.entries(manifest.platforms).forEach(([key, platform]) => {
-    validatePlatform(key, platform, releaseTag);
+  Object.entries(platforms).forEach(([key, platform]) => {
+    validatePlatform(key, platform, releaseTag, distribution);
   });
 
   const matchedPlatforms = REQUIRED_PLATFORM_GROUPS.map(({ keys, label }) => {
-    const key = keys.find((candidate) => candidate in manifest.platforms!);
+    const key = keys.find((candidate) => candidate in platforms);
     if (!key) {
       throw new Error(
         `更新清单缺少 ${label}，需要以下平台键之一：${keys.join(", ")}`,
@@ -122,10 +138,18 @@ if (import.meta.main) {
   try {
     const manifestPath = process.argv[2];
     const releaseTag = process.argv[3] ?? "";
+    const distribution = process.argv[4] ?? "github";
     if (!manifestPath) throw new Error("缺少 latest.json 路径");
+    if (distribution !== "github" && distribution !== "gitee") {
+      throw new Error(`不支持的更新分发源：${distribution}`);
+    }
 
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    const platforms = validateUpdaterManifest(manifest, releaseTag);
+    const platforms = validateUpdaterManifest(
+      manifest,
+      releaseTag,
+      distribution,
+    );
     console.log(`更新清单校验通过：${platforms.join(", ")}`);
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERCNjFDQ0VGNzRBMzZDQTUKUldTbGJLTjA3OHhoMjFNcjM4SHBGc1J3ZThJdC9LU3poMHFJV2g2aDR0ZmlEdHRZMzlrQUdTbisK",
       "endpoints": [
+        "https://gitee.com/Max0897/FineShell/raw/ota/latest.json",
         "https://github.com/Max0897/fineshell/releases/latest/download/latest.json"
       ],
       "windows": {

--- a/src/updater-config.test.ts
+++ b/src/updater-config.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import tauriConfig from "../src-tauri/tauri.conf.json";
+
+describe("updater endpoints", () => {
+  test("checks Gitee before falling back to GitHub", () => {
+    expect(tauriConfig.plugins.updater.endpoints).toEqual([
+      "https://gitee.com/Max0897/FineShell/raw/ota/latest.json",
+      "https://github.com/Max0897/fineshell/releases/latest/download/latest.json",
+    ]);
+  });
+});


### PR DESCRIPTION
## 变更内容

- 使用 GitHub Actions 自动同步 main 与版本标签到 Gitee
- GitHub Release 发布成功后同步安装包、签名和发布说明到 Gitee Release
- 生成 Gitee 版更新清单并维护稳定的 ota 地址
- Tauri 更新器优先使用 Gitee，失败后回退 GitHub
- 增加 Gitee 附件映射、清单校验与更新源顺序测试

## 验证

- `bun run check`
- 346 项前端测试通过
- 生产构建通过
- 双源更新专项测试 16 项通过
- Release 工作流 YAML 结构与格式检查通过