### PR TITLE
修复 Gitee Release 同步

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: "版本标签，例如 v0.1.0（必须与应用版本一致）"
         required: true
         type: string
+      sync_gitee_only:
+        description: "仅重试 Gitee Release 与 OTA 清单同步"
+        default: false
+        required: false
+        type: boolean
   push:
     tags:
       - "v*"
@@ -55,6 +60,7 @@ jobs:
   prepare:
     name: Prepare draft release
     needs: validate
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.sync_gitee_only) }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -93,6 +99,7 @@ jobs:
       - prepare
     permissions:
       contents: write
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.sync_gitee_only) }}
     strategy:
       fail-fast: false
       matrix:
@@ -216,6 +223,7 @@ jobs:
       - build
     permissions:
       contents: write
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.sync_gitee_only) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -273,6 +281,7 @@ jobs:
       - publish
     permissions:
       contents: read
+    if: ${{ always() && needs.validate.result == 'success' && (needs.publish.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.sync_gitee_only)) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -334,9 +343,10 @@ jobs:
           GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
           RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
         run: |
+          release_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
           bun scripts/publish-gitee-release.ts \
             "$RELEASE_TAG" \
-            "$GITHUB_SHA" \
+            "$release_commit" \
             "$RUNNER_TEMP/release-notes.md" \
             "$RUNNER_TEMP/gitee-assets" \
             "$RUNNER_TEMP/gitee-assets/latest.json" \

--- a/scripts/publish-gitee-release.test.ts
+++ b/scripts/publish-gitee-release.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { createGiteeUpdaterManifest } from "./publish-gitee-release";
+import {
+  createGiteeUpdaterManifest,
+  parseGiteeReleaseLookup,
+} from "./publish-gitee-release";
 
 const githubUrl =
   "https://github.com/Max0897/fineshell/releases/download/v1.2.3/FineShell_1.2.3_windows_x64-setup.exe";
@@ -104,5 +107,19 @@ describe("Gitee updater manifest", () => {
         },
       ]),
     ).toThrow("必须使用 gitee.com HTTPS 地址");
+  });
+});
+
+describe("Gitee release lookup", () => {
+  test("treats a successful null response as a missing release", () => {
+    expect(parseGiteeReleaseLookup(null)).toBeNull();
+  });
+
+  test("returns a valid release ID", () => {
+    expect(parseGiteeReleaseLookup({ id: 42 })).toEqual({ id: 42 });
+  });
+
+  test("rejects malformed release responses", () => {
+    expect(() => parseGiteeReleaseLookup({ id: "42" })).toThrow("缺少有效 ID");
   });
 });

--- a/scripts/publish-gitee-release.ts
+++ b/scripts/publish-gitee-release.ts
@@ -44,6 +44,13 @@ function parseRelease(value: unknown): GiteeRelease {
   return { id: Number(value.id) };
 }
 
+export function parseGiteeReleaseLookup(value: unknown): GiteeRelease | null {
+  // Gitee returns HTTP 200 with a JSON null body when the tag exists but a
+  // corresponding Release has not been created yet.
+  if (value === null) return null;
+  return parseRelease(value);
+}
+
 function parseAttachment(value: unknown): GiteeAttachment {
   if (
     !isRecord(value) ||
@@ -179,7 +186,7 @@ class GiteeReleaseClient {
       this.authenticatedUrl(`/releases/tags/${encodeURIComponent(tag)}`),
     );
     if (response.status === 404) return null;
-    return parseRelease(
+    return parseGiteeReleaseLookup(
       await this.responseJson(response, 200, "查询 Gitee Release"),
     );
   }


### PR DESCRIPTION
## 修改内容

- 兼容 Gitee 查询不存在 Release 时返回 `HTTP 200 + null`
- 增加 Gitee Release 响应回归测试
- 支持手动仅重试 Gitee Release/OTA 同步，无需重复构建安装包
- 同步时使用版本标签实际指向的提交

## 验证

- `bun run check`
- Gitee 发布与更新清单单元测试（18 项）
- Prettier 检查