### PR TITLE
修复 Gitee 流水线变量名

### DIFF
--- a/.giteego/release.yml
+++ b/.giteego/release.yml
@@ -11,7 +11,7 @@ triggers:
         - gitee-release-trigger
 
 variables:
-  GITEE_ACCESS_TOKEN: ${{GITEE_ACCESS_TOKEN}}
+  FINESHELL_RELEASE_TOKEN: ${{FINESHELL_RELEASE_TOKEN}}
 
 stages:
   - stage:

--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
-版本标签会触发 GitHub Actions 构建 macOS、Linux 和 Windows 安装包；所有平台构建成功后，工作流会将 `CHANGELOG.md` 中对应版本的内容写入 GitHub Release，随后同步相同的安装包、签名和发布说明到 Gitee Release。客户端优先使用 Gitee 更新清单，Gitee 不可用时自动回退到 GitHub。
+版本标签会触发 GitHub Actions 构建 macOS、Linux 和 Windows 安装包；所有平台构建成功后，工作流会将 `CHANGELOG.md` 中对应版本的内容写入 GitHub Release，再触发 Gitee 流水线同步安装包、签名、发布说明和 OTA 更新清单。客户端优先使用 Gitee 更新清单，Gitee 不可用时自动回退到 GitHub。
 
-Gitee 发布同步需要在 GitHub 仓库中配置 `GITEE_ACCESS_TOKEN`、`GITEE_SSH_PRIVATE_KEY` 和 `GITEE_KNOWN_HOSTS` 三个 Secrets。
+GitHub 仓库需要配置 `GITEE_SSH_PRIVATE_KEY` 和 `GITEE_KNOWN_HOSTS`；Gitee 流水线需要单独配置密文变量 `FINESHELL_RELEASE_TOKEN`。完整架构与失败重试方式见 [发布流水线文档](docs/release-pipeline.md)。
 
 ## 支持项目
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -17,7 +17,7 @@ GitHub Actions 需要以下仓库密钥：
 - `GITEE_SSH_PRIVATE_KEY`：用于同步 Gitee 标签和发布触发分支。
 - `GITEE_KNOWN_HOSTS`：Gitee SSH 主机指纹。
 
-`GITEE_ACCESS_TOKEN` 不再由 GitHub Actions 使用，可以从 GitHub 仓库密钥中移除。
+Gitee API 访问令牌不再由 GitHub Actions 使用，旧的访问令牌仓库密钥可以移除。
 
 ## Gitee 配置
 
@@ -25,7 +25,7 @@ GitHub Actions 需要以下仓库密钥：
 
 在 Gitee 项目的流水线设置中创建密钥变量：
 
-- 名称：`GITEE_ACCESS_TOKEN`
+- 名称：`FINESHELL_RELEASE_TOKEN`
 - 类型：密钥变量
 - 权限：能够管理当前仓库的 Release，并能够推送 `ota` 分支
 

--- a/scripts/gitee-pipeline-release.sh
+++ b/scripts/gitee-pipeline-release.sh
@@ -8,8 +8,8 @@ test -f "$trigger_file" || {
   echo "缺少 .gitee-release-trigger.json，拒绝发布。" >&2
   exit 1
 }
-test -n "${GITEE_ACCESS_TOKEN:-}" || {
-  echo "缺少 GITEE_ACCESS_TOKEN 流水线密钥变量。" >&2
+test -n "${FINESHELL_RELEASE_TOKEN:-}" || {
+  echo "缺少 FINESHELL_RELEASE_TOKEN 流水线密钥变量。" >&2
   exit 1
 }
 
@@ -39,7 +39,7 @@ cat > "$askpass_file" <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   *Username*) printf '%s\n' 'oauth2' ;;
-  *) printf '%s\n' "$GITEE_ACCESS_TOKEN" ;;
+  *) printf '%s\n' "$FINESHELL_RELEASE_TOKEN" ;;
 esac
 EOF
 chmod 700 "$askpass_file"

--- a/scripts/gitee_pipeline_release.py
+++ b/scripts/gitee_pipeline_release.py
@@ -395,9 +395,9 @@ def create_gitee_updater_manifest(
 
 
 def publish(trigger_path: Path, assets_directory: Path, output_path: Path) -> None:
-    token = os.environ.get("GITEE_ACCESS_TOKEN", "").strip()
+    token = os.environ.get("FINESHELL_RELEASE_TOKEN", "").strip()
     if not token:
-        raise ReleaseError("缺少 GITEE_ACCESS_TOKEN 流水线密钥变量")
+        raise ReleaseError("缺少 FINESHELL_RELEASE_TOKEN 流水线密钥变量")
     owner = os.environ.get("GITEE_OWNER", "Max0897").strip()
     repository = os.environ.get("GITEE_REPOSITORY", "FineShell").strip()
     trigger = load_trigger(trigger_path)


### PR DESCRIPTION
## 改动

- 将 Gitee 流水线密钥变量改为 `FINESHELL_RELEASE_TOKEN`
- 同步修改 Python、Bash 发布脚本
- 修正 README 和发布运维文档中的配置说明

## 原因

Gitee 保留 `GITEE_` 变量前缀，项目变量无法使用原名称。

## 验证

- Python 发布脚本 5 项单元测试通过
- Python、Bash 与 YAML 语法检查通过
- `git diff --check` 通过