### PR TITLE
修复 Gitee 发布流水线 Python 环境

### DIFF
--- a/.workflow/fineshell-release.yml
+++ b/.workflow/fineshell-release.yml
@@ -21,5 +21,6 @@ stages:
       - step: build@python
         name: publish-release
         displayName: 同步安装包并更新 OTA
+        pythonVersion: "3.11"
         commands:
           - bash scripts/gitee-pipeline-release.sh

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -29,7 +29,7 @@ Gitee API 访问令牌不再由 GitHub Actions 使用，旧的访问令牌仓库
 - 类型：密钥变量
 - 权限：能够管理当前仓库的 Release，并能够推送 `ota` 分支
 
-流水线运行环境需要提供 `bash`、`curl`、`git` 和 `python3`。发布脚本只使用 Python 标准库，不需要安装项目依赖。
+流水线使用 Gitee Python 3.11 构建环境，并需要提供 `bash`、`curl` 和 `git`。发布脚本只使用 Python 标准库，不需要安装项目依赖。
 
 ## 失败重试
 


### PR DESCRIPTION
## 修改内容

- 将 Gitee 发布任务固定到 Python 3.11
- 更新发布流水线运行环境文档

## 原因

Gitee 的 `build@python` 插件未指定版本时默认使用 Python 2.7，Runner 中不存在发布脚本所需的 `python3` 命令，导致同步 GitHub Release 失败。

## 影响

合并后重新触发 GitHub Release 的“仅同步 Gitee”模式，即可由 Gitee 流水线拉取并发布现有安装包；后续版本也会沿用该环境自动同步。

## 验证

- `python3 -m unittest discover -s scripts -p "test_*.py"`
- `bash -n scripts/gitee-pipeline-release.sh`
- 流水线 YAML 解析及 Python 版本断言
- `git diff --check`