### PR TITLE
修复 Gitee 流水线密钥注入

### DIFF
--- a/.workflow/fineshell-release.yml
+++ b/.workflow/fineshell-release.yml
@@ -11,7 +11,8 @@ triggers:
         - gitee-release-trigger
 
 variables:
-  FINESHELL_RELEASE_TOKEN: ${{FINESHELL_RELEASE_TOKEN}}
+  global:
+    - FINESHELL_RELEASE_TOKEN
 
 stages:
   - stage:

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -23,10 +23,10 @@ Gitee API 访问令牌不再由 GitHub Actions 使用，旧的访问令牌仓库
 
 流水线配置位于 `.workflow/fineshell-release.yml`，监听 `gitee-release-trigger` 分支。流水线配置以 GitHub 仓库为准，不要直接在 Gitee 页面中修改，以免两个仓库的 `main` 分支产生分叉。
 
-在 Gitee 项目的流水线设置中创建密钥变量：
+在 Gitee 项目的通用变量中创建密文变量；流水线配置会通过 `variables.global` 自动关联：
 
 - 名称：`FINESHELL_RELEASE_TOKEN`
-- 类型：密钥变量
+- 类型：密文
 - 权限：能够管理当前仓库的 Release，并能够推送 `ota` 分支
 
 流水线使用 Gitee Python 3.11 构建环境，并需要提供 `bash`、`curl` 和 `git`。发布脚本只使用 Python 标准库，不需要安装项目依赖。

--- a/scripts/gitee-pipeline-release.sh
+++ b/scripts/gitee-pipeline-release.sh
@@ -8,10 +8,12 @@ test -f "$trigger_file" || {
   echo "缺少 .gitee-release-trigger.json，拒绝发布。" >&2
   exit 1
 }
-test -n "${FINESHELL_RELEASE_TOKEN:-}" || {
-  echo "缺少 FINESHELL_RELEASE_TOKEN 流水线密钥变量。" >&2
-  exit 1
-}
+case "${FINESHELL_RELEASE_TOKEN:-}" in
+  ""|*'${{'*|*'}}'*)
+    echo "FINESHELL_RELEASE_TOKEN 通用变量未正确注入流水线。" >&2
+    exit 1
+    ;;
+esac
 
 for command_name in curl git python3; do
   command -v "$command_name" >/dev/null 2>&1 || {


### PR DESCRIPTION
## 修改内容

- 使用 Gitee Cloud `variables.global` 关联 `FINESHELL_RELEASE_TOKEN` 通用变量
- 拒绝把未展开的 `${{...}}` 占位符当作访问令牌
- 更新 Gitee 通用变量配置文档

## 原因

原配置沿用了 GitHub 风格占位符，Gitee 将 `${{FINESHELL_RELEASE_TOKEN}}` 作为普通字符串注入，调用 Release API 时返回 401。

## 影响

合并后 Gitee Runner 会读取项目通用变量中的真实密文 Token，重新触发后可继续同步 GitHub Release 附件和 OTA 清单。

## 验证

- 5 项发布脚本单元测试通过
- Bash 语法检查通过
- 流水线 YAML 解析及全局变量、Python 版本断言通过
- `git diff --check` 通过