### PR TITLE
新增终端历史补全与字体缩放

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,11 @@ import {
   type TerminalInjectedInput,
 } from "./terminal-utils";
 import {
+  nextTerminalFontSizeOffset,
+  terminalFontSize,
+  type TerminalFontZoomAction,
+} from "./terminal-font-zoom";
+import {
   configureDiagnosticLogging,
   diagnosticInvoke as invoke,
   recordDiagnostic,
@@ -133,6 +138,7 @@ function App() {
     Record<string, number>
   >({});
   const [terminalFocusRequest, setTerminalFocusRequest] = useState(0);
+  const [terminalFontSizeOffset, setTerminalFontSizeOffset] = useState(0);
   const mainSplitRef = useRef<HTMLElement | null>(null);
   const handleSessionsClosed = useCallback((closingIds: Set<string>) => {
     setAiRemoteFileContexts((currentContexts) =>
@@ -199,6 +205,27 @@ function App() {
     sidebarWidth: aiSidebarWidth,
   });
   const previousAiSidebarPhaseRef = useRef(aiSidebarPhase);
+
+  const runtimeTerminalFontSize = terminalFontSize(
+    settings.terminalFontSize,
+    terminalFontSizeOffset,
+  );
+  const zoomTerminalFont = useCallback(
+    (action: TerminalFontZoomAction) => {
+      setTerminalFontSizeOffset((currentOffset) =>
+        nextTerminalFontSizeOffset(
+          settings.terminalFontSize,
+          currentOffset,
+          action,
+        ),
+      );
+    },
+    [settings.terminalFontSize],
+  );
+
+  useEffect(() => {
+    setTerminalFontSizeOffset(0);
+  }, [settings.terminalFontSize]);
 
   useEffect(() => {
     if (
@@ -688,8 +715,10 @@ function App() {
                 session.id === activeSessionId ? terminalFocusRequest : 0
               }
               injectedInput={terminalInjectedInputs[session.id]}
+              onFontZoom={zoomTerminalFont}
               settings={settings}
               session={session}
+              terminalFontSize={runtimeTerminalFontSize}
               onAskAi={(selection) => {
                 setTerminalSelections((current) => ({
                   ...current,

--- a/src/components/PrivacySettings.tsx
+++ b/src/components/PrivacySettings.tsx
@@ -20,6 +20,7 @@ import {
 } from "../config-database";
 import {
   clearConnectionHistory,
+  clearTerminalCommandHistory,
   removeCredentialReference,
   replaceCredentialReferences,
 } from "../configuration-mutations";
@@ -73,6 +74,7 @@ function PrivacySettings({
   updateSetting,
 }: PrivacySettingsProps) {
   const [historyCount, setHistoryCount] = useState(0);
+  const [terminalHistoryCount, setTerminalHistoryCount] = useState(0);
   const [orphaned, setOrphaned] = useState<CredentialReferenceRecord[]>([]);
   const [hasScanned, setHasScanned] = useState(false);
   const [scanning, setScanning] = useState(false);
@@ -81,6 +83,7 @@ function PrivacySettings({
   const scanCredentials = useCallback(async () => {
     const configuration = await loadConfiguration();
     setHistoryCount(configuration.history.length);
+    setTerminalHistoryCount(configuration.terminalCommandHistory.length);
     if (!isTauri()) {
       setOrphaned([]);
       return;
@@ -118,7 +121,10 @@ function PrivacySettings({
 
   useEffect(() => {
     void loadConfiguration()
-      .then((configuration) => setHistoryCount(configuration.history.length))
+      .then((configuration) => {
+        setHistoryCount(configuration.history.length);
+        setTerminalHistoryCount(configuration.terminalCommandHistory.length);
+      })
       .catch((error) => Message.error(String(error)));
   }, [
     savedSettings.connectionHistoryLimit,
@@ -137,6 +143,22 @@ function PrivacySettings({
       Message.success("连接历史已清空");
       setHasScanned(false);
       setOrphaned([]);
+    } catch (error) {
+      Message.error(String(error));
+      throw error;
+    }
+  };
+
+  const clearTerminalHistory = async () => {
+    try {
+      await clearTerminalCommandHistory();
+      setTerminalHistoryCount(0);
+      if (isTauri()) {
+        await emitProtocolEventTo("main", "configuration:changed").catch(
+          () => undefined,
+        );
+      }
+      Message.success("终端命令历史已清空");
     } catch (error) {
       Message.error(String(error));
       throw error;
@@ -277,6 +299,26 @@ function PrivacySettings({
               />
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="privacy-section">
+        <div className="privacy-section-heading">
+          <div>
+            <Typography.Title heading={6}>终端命令历史</Typography.Title>
+            <Typography.Text type="secondary">
+              当前保存 {terminalHistoryCount} 条，仅保存在本机且不会随配置导出
+            </Typography.Text>
+          </div>
+          <Popconfirm
+            content="确定清空全部终端命令历史？清空后将无法继续使用历史自动补全。"
+            disabled={terminalHistoryCount === 0}
+            onOk={clearTerminalHistory}
+          >
+            <Button disabled={terminalHistoryCount === 0} status="danger">
+              清空历史
+            </Button>
+          </Popconfirm>
         </div>
       </section>
 

--- a/src/components/ShortcutGuideWindow.test.tsx
+++ b/src/components/ShortcutGuideWindow.test.tsx
@@ -8,6 +8,8 @@ describe("ShortcutGuideWindow", () => {
 
     expect(screen.getByText("打开快捷命令")).toBeTruthy();
     expect(screen.getByText("查找终端内容")).toBeTruthy();
+    expect(screen.getByText("调整终端字号")).toBeTruthy();
+    expect(screen.getByText("恢复终端字号")).toBeTruthy();
     expect(screen.getByText("选中全部文件")).toBeTruthy();
     expect(screen.getByText("反选文件")).toBeTruthy();
     const currentShortcut = shortcutGuideRows()[0].shortcut;

--- a/src/components/ShortcutGuideWindow.tsx
+++ b/src/components/ShortcutGuideWindow.tsx
@@ -62,6 +62,22 @@ export const SHORTCUT_GUIDE_ITEMS: ShortcutGuideItem[] = [
     description: "返回当前终端",
   },
   {
+    key: "terminal-font-zoom",
+    category: "终端",
+    action: "调整终端字号",
+    mac: "Command + +/- 或滚轮",
+    other: "Ctrl + +/- 或滚轮",
+    description: "仅临时调整当前窗口中的终端字号",
+  },
+  {
+    key: "terminal-font-reset",
+    category: "终端",
+    action: "恢复终端字号",
+    mac: "Command + 0",
+    other: "Ctrl + 0",
+    description: "恢复设置中配置的终端字号",
+  },
+  {
     key: "files-select-all",
     category: "文件管理",
     action: "选中全部文件",

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -65,6 +65,11 @@ import {
   type ShellIntegrationEchoFilter,
 } from "../shell-integration";
 import { TERMINAL_THEMES } from "../terminal-themes";
+import {
+  terminalFontZoomKeyboardAction,
+  terminalFontZoomWheelAction,
+  type TerminalFontZoomAction,
+} from "../terminal-font-zoom";
 import { diagnosticInvoke as invoke } from "../diagnostics";
 import { listenProtocolEvent } from "../tauri-protocol";
 import ConnectionStatusOverlay from "./ConnectionStatusOverlay";
@@ -75,8 +80,10 @@ interface TerminalViewProps {
   commandTrackingEnabled: boolean;
   focusRequest: number;
   injectedInput?: TerminalInjectedInput;
+  onFontZoom: (action: TerminalFontZoomAction) => void;
   settings: AppSettings;
   session: TerminalSession;
+  terminalFontSize: number;
   onAskAi: (selection: string) => void;
   onCommandLifecycle: (event: TerminalCommandSubmission) => void;
   onCurrentDirectoryChange: (sessionId: string, path: string) => void;
@@ -138,8 +145,10 @@ function TerminalView({
   commandTrackingEnabled,
   focusRequest,
   injectedInput,
+  onFontZoom,
   settings,
   session,
+  terminalFontSize,
   onAskAi,
   onCommandLifecycle,
   onCurrentDirectoryChange,
@@ -190,6 +199,8 @@ function TerminalView({
   const selectionChangeRef = useRef(onSelectionChange);
   const currentDirectoryChangeRef = useRef(onCurrentDirectoryChange);
   const settingsRef = useRef(settings);
+  const fontZoomRef = useRef(onFontZoom);
+  const lastWheelZoomAtRef = useRef(Number.NEGATIVE_INFINITY);
   const searchVisibleRef = useRef(false);
   const lastStatusNoticeRef = useRef<string>();
   const [searchVisible, setSearchVisible] = useState(false);
@@ -201,6 +212,7 @@ function TerminalView({
 
   searchVisibleRef.current = searchVisible;
   settingsRef.current = settings;
+  fontZoomRef.current = onFontZoom;
   commandLifecycleRef.current = onCommandLifecycle;
   commandTrackingEnabledRef.current = commandTrackingEnabled;
   shellCommandResultsEnabledRef.current = commandTrackingEnabled;
@@ -426,7 +438,7 @@ function TerminalView({
       cursorStyle: settings.terminalCursorStyle,
       cursorWidth: 1,
       fontFamily: TERMINAL_FONT_FAMILIES[settings.terminalFontFamily],
-      fontSize: settings.terminalFontSize,
+      fontSize: terminalFontSize,
       lineHeight: settings.terminalLineHeight,
       overviewRuler: {
         width: 6,
@@ -460,6 +472,13 @@ function TerminalView({
     terminal.loadAddon(historyCompletionAddon);
     terminal.open(container);
     terminal.attachCustomKeyEventHandler((event) => {
+      const zoomAction = terminalFontZoomKeyboardAction(event);
+      if (zoomAction) {
+        event.preventDefault();
+        event.stopPropagation();
+        fontZoomRef.current(zoomAction);
+        return false;
+      }
       if (isWindowsTerminalPasteShortcut(event)) {
         event.preventDefault();
         event.stopPropagation();
@@ -707,6 +726,28 @@ function TerminalView({
   }, [session.id]);
 
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      const zoomAction = terminalFontZoomWheelAction(event);
+      if (!zoomAction) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const now = performance.now();
+      if (now - lastWheelZoomAtRef.current < 80) return;
+      lastWheelZoomAtRef.current = now;
+      fontZoomRef.current(zoomAction);
+    };
+
+    container.addEventListener("wheel", handleWheel, {
+      capture: true,
+      passive: false,
+    });
+    return () => container.removeEventListener("wheel", handleWheel, true);
+  }, []);
+
+  useEffect(() => {
     const searchAddon = searchAddonRef.current;
     if (!searchAddon || !searchVisible) return;
     if (!searchQuery) {
@@ -745,7 +786,7 @@ function TerminalView({
     terminal.options.cursorWidth = 1;
     terminal.options.fontFamily =
       TERMINAL_FONT_FAMILIES[settings.terminalFontFamily];
-    terminal.options.fontSize = settings.terminalFontSize;
+    terminal.options.fontSize = terminalFontSize;
     terminal.options.lineHeight = settings.terminalLineHeight;
     terminal.options.scrollback = settings.terminalScrollback;
     terminal.options.theme =
@@ -763,7 +804,7 @@ function TerminalView({
     settings.terminalCursorStyle,
     settings.terminalColorScheme,
     settings.terminalFontFamily,
-    settings.terminalFontSize,
+    terminalFontSize,
     settings.terminalLineHeight,
     settings.terminalScrollback,
   ]);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -31,9 +31,13 @@ import {
 } from "@xterm/addon-search";
 import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import type { TerminalSession } from "../models";
+import type {
+  TerminalCommandHistoryRecord,
+  TerminalSession,
+} from "../models";
 import { TERMINAL_FONT_FAMILIES, type AppSettings } from "../app-settings";
 import {
+  appendInjectedTerminalInput,
   consumeTerminalCommandCandidate,
   decodeSshOutput,
   EMPTY_TERMINAL_INPUT_STATE,
@@ -46,6 +50,9 @@ import {
   trackTerminalInput,
   type TerminalInjectedInput,
 } from "../terminal-utils";
+import { loadConfiguration } from "../config-database";
+import { recordTerminalCommandHistory } from "../configuration-mutations";
+import { TerminalHistoryCompletionAddon } from "../terminal-history-completion";
 import {
   FINESHELL_OSC_ID,
   boundedShellCommandOutput,
@@ -144,6 +151,9 @@ function TerminalView({
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
+  const historyCompletionRef = useRef<TerminalHistoryCompletionAddon | null>(
+    null,
+  );
   const searchInputRef = useRef<RefInputType>(null);
   const connectedRef = useRef(isTerminalSessionOperational(session.status));
   const commandLifecycleRef = useRef(onCommandLifecycle);
@@ -165,8 +175,14 @@ function TerminalView({
   >(() => undefined);
   const pendingShellCommandsRef = useRef<PendingShellCommand[]>([]);
   const aiCommandCandidatesRef = useRef<string[]>([]);
+  const terminalCommandHistoryRef = useRef<TerminalCommandHistoryRecord[]>([]);
+  const terminalHistoryWriteRef = useRef<Promise<void>>(Promise.resolve());
+  const currentDirectoryRef = useRef("");
   const inputStateRef = useRef({ ...EMPTY_TERMINAL_INPUT_STATE });
   const trackSubmittedCommandRef = useRef<(command: string) => void>(
+    () => undefined,
+  );
+  const recordTerminalHistoryRef = useRef<(command: string) => void>(
     () => undefined,
   );
   const lastInjectedInputIdRef = useRef<string>();
@@ -191,6 +207,26 @@ function TerminalView({
   currentDirectoryChangeRef.current = onCurrentDirectoryChange;
   recentOutputChangeRef.current = onRecentOutputChange;
   selectionChangeRef.current = onSelectionChange;
+
+  recordTerminalHistoryRef.current = (command) => {
+    const hostId = session.host.id;
+    const cwd = currentDirectoryRef.current || undefined;
+    terminalHistoryWriteRef.current = terminalHistoryWriteRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        const configuration = await recordTerminalCommandHistory(
+          hostId,
+          command,
+          cwd,
+        );
+        terminalCommandHistoryRef.current =
+          configuration.terminalCommandHistory;
+        historyCompletionRef.current?.setHistory(
+          configuration.terminalCommandHistory,
+        );
+      })
+      .catch(() => undefined);
+  };
 
   trackSubmittedCommandRef.current = (command) => {
     const candidate = consumeTerminalCommandCandidate(
@@ -262,6 +298,7 @@ function TerminalView({
     ) {
       return;
     }
+    historyCompletionRef.current?.setPromptReady(false);
     shellIntegrationMutationRef.current = mutation;
     if (mutation === "install") {
       shellIntegrationInstalledRef.current = true;
@@ -293,6 +330,7 @@ function TerminalView({
   useEffect(() => {
     connectedRef.current = isTerminalSessionOperational(session.status);
     if (!isTerminalSessionOperational(session.status)) {
+      currentDirectoryRef.current = "";
       currentDirectoryChangeRef.current(session.id, "");
       const completedAt = new Date().toISOString();
       for (const pending of pendingShellCommandsRef.current) {
@@ -312,6 +350,8 @@ function TerminalView({
       clearShellIntegrationTimeout();
       aiCommandCandidatesRef.current = [];
       inputStateRef.current = { ...EMPTY_TERMINAL_INPUT_STATE };
+      historyCompletionRef.current?.setPromptReady(false);
+      historyCompletionRef.current?.synchronizeInput("", true);
     }
   }, [session.status]);
 
@@ -320,6 +360,7 @@ function TerminalView({
     pendingShellCommandsRef.current = [];
     aiCommandCandidatesRef.current = [];
     inputStateRef.current = { ...EMPTY_TERMINAL_INPUT_STATE };
+    historyCompletionRef.current?.synchronizeInput("", true);
   }, [commandTrackingEnabled]);
 
   useEffect(() => {
@@ -348,15 +389,25 @@ function TerminalView({
         ),
         injectedInput.value,
       ].slice(-8);
-      const tracked = trackInjectedTerminalInput(
-        inputStateRef.current,
-        injectedInput,
-      );
-      inputStateRef.current = tracked.state;
-      tracked.submissions.forEach((command) =>
-        trackSubmittedCommandRef.current(command),
-      );
     }
+    const tracked = trackInjectedTerminalInput(
+      inputStateRef.current,
+      injectedInput,
+    );
+    inputStateRef.current = tracked.state;
+    historyCompletionRef.current?.synchronizeInput(
+      tracked.state.value,
+      tracked.state.reliable,
+    );
+    if (injectedInput.submit) {
+      historyCompletionRef.current?.setPromptReady(false);
+    }
+    tracked.submissions.forEach((command) => {
+      recordTerminalHistoryRef.current(command);
+      if (commandTrackingEnabled || injectedInput.submit) {
+        trackSubmittedCommandRef.current(command);
+      }
+    });
     const data = terminalInjectedInputData(injectedInput);
     void invoke("ssh_write", {
       sessionId: session.id,
@@ -385,17 +436,40 @@ function TerminalView({
     });
     const fitAddon = new FitAddon();
     const searchAddon = new SearchAddon({ highlightLimit: 1000 });
+    const historyCompletionAddon = new TerminalHistoryCompletionAddon({
+      hostId: session.host.id,
+      getCurrentDirectory: () => currentDirectoryRef.current || undefined,
+      onAccept: (suffix) => {
+        inputStateRef.current = appendInjectedTerminalInput(
+          inputStateRef.current,
+          suffix,
+        );
+        historyCompletionAddon.synchronizeInput(
+          inputStateRef.current.value,
+          inputStateRef.current.reliable,
+        );
+        if (!connectedRef.current) return;
+        void invoke("ssh_write", {
+          sessionId: session.id,
+          data: Array.from(new TextEncoder().encode(suffix)),
+        }).catch(() => undefined);
+      },
+    });
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(searchAddon);
+    terminal.loadAddon(historyCompletionAddon);
     terminal.open(container);
     terminal.attachCustomKeyEventHandler((event) => {
-      if (!isWindowsTerminalPasteShortcut(event)) return true;
-      event.preventDefault();
-      event.stopPropagation();
-      if (!event.repeat) void pasteTerminalClipboard();
-      return false;
+      if (isWindowsTerminalPasteShortcut(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!event.repeat) void pasteTerminalClipboard();
+        return false;
+      }
+      return historyCompletionAddon.handleKeyEvent(event);
     });
     terminalRef.current = terminal;
+    historyCompletionRef.current = historyCompletionAddon;
     lastStatusNoticeRef.current = undefined;
     fitAddonRef.current = fitAddon;
     searchAddonRef.current = searchAddon;
@@ -403,6 +477,15 @@ function TerminalView({
     aiCommandCandidatesRef.current = [];
     pendingShellCommandsRef.current = [];
     lastInjectedInputIdRef.current = undefined;
+    currentDirectoryRef.current = "";
+
+    const loadTerminalHistory = () =>
+      loadConfiguration().then((configuration) => {
+        terminalCommandHistoryRef.current =
+          configuration.terminalCommandHistory;
+        historyCompletionAddon.setHistory(configuration.terminalCommandHistory);
+      });
+    void loadTerminalHistory().catch(() => undefined);
 
     const fit = () => {
       if (container.clientWidth === 0 || container.clientHeight === 0) return;
@@ -426,13 +509,21 @@ function TerminalView({
 
     const dataDisposable = terminal.onData((data) => {
       if (!connectedRef.current || shellIntegrationMutationRef.current) return;
-      if (commandTrackingEnabledRef.current) {
-        const tracked = trackTerminalInput(inputStateRef.current, data);
-        inputStateRef.current = tracked.state;
-        tracked.submissions.forEach((command) =>
-          trackSubmittedCommandRef.current(command),
-        );
+      const tracked = trackTerminalInput(inputStateRef.current, data);
+      inputStateRef.current = tracked.state;
+      historyCompletionAddon.synchronizeInput(
+        tracked.state.value,
+        tracked.state.reliable,
+      );
+      if (data.includes("\r") || data.includes("\n")) {
+        historyCompletionAddon.setPromptReady(false);
       }
+      tracked.submissions.forEach((command) => {
+        recordTerminalHistoryRef.current(command);
+        if (commandTrackingEnabledRef.current) {
+          trackSubmittedCommandRef.current(command);
+        }
+      });
       void invoke("ssh_write", {
         sessionId: session.id,
         data: Array.from(new TextEncoder().encode(data)),
@@ -467,10 +558,13 @@ function TerminalView({
         if (!message) return false;
         if (message.kind === "ready") {
           settleShellIntegrationMutationRef.current("ready");
+          historyCompletionAddon.setPromptReady(true);
           return true;
         }
         if (message.kind === "disabled") {
           settleShellIntegrationMutationRef.current("disabled");
+          historyCompletionAddon.setPromptReady(false);
+          currentDirectoryRef.current = "";
           currentDirectoryChangeRef.current(session.id, "");
           queueMicrotask(() =>
             startShellIntegrationMutationRef.current("install"),
@@ -478,11 +572,15 @@ function TerminalView({
           return true;
         }
         if (message.kind === "cwd") {
+          currentDirectoryRef.current = message.path;
           currentDirectoryChangeRef.current(session.id, message.path);
+          historyCompletionAddon.setHistory(terminalCommandHistoryRef.current);
           return true;
         }
         if (message.kind === "unavailable") {
           settleShellIntegrationMutationRef.current("unavailable");
+          historyCompletionAddon.setPromptReady(false);
+          currentDirectoryRef.current = "";
           currentDirectoryChangeRef.current(session.id, "");
           const completedAt = new Date().toISOString();
           for (const pending of pendingShellCommandsRef.current) {
@@ -498,6 +596,7 @@ function TerminalView({
           return true;
         }
 
+        historyCompletionAddon.setPromptReady(true);
         const pending = pendingShellCommandsRef.current.shift();
         if (!pending) return true;
         window.setTimeout(() => {
@@ -533,6 +632,7 @@ function TerminalView({
 
     let disposed = false;
     let unlisten: (() => void) | undefined;
+    let unlistenConfiguration: (() => void) | undefined;
     let recentOutputTimer: ReturnType<typeof setTimeout> | undefined;
     const emitRecentOutput = () => {
       recentOutputTimer = undefined;
@@ -575,6 +675,12 @@ function TerminalView({
         setTerminalReady(true);
       }
     });
+    void listenProtocolEvent("configuration:changed", () => {
+      void loadTerminalHistory().catch(() => undefined);
+    }).then((stopListening) => {
+      if (disposed) stopListening();
+      else unlistenConfiguration = stopListening;
+    });
 
     return () => {
       disposed = true;
@@ -583,6 +689,7 @@ function TerminalView({
       shellIntegrationMutationRef.current = undefined;
       shellIntegrationEchoFilterRef.current = undefined;
       unlisten?.();
+      unlistenConfiguration?.();
       if (recentOutputTimer) clearTimeout(recentOutputTimer);
       resizeObserver.disconnect();
       if (fitFrame !== undefined) cancelAnimationFrame(fitFrame);
@@ -593,6 +700,7 @@ function TerminalView({
       shellIntegrationDisposable.dispose();
       terminal.dispose();
       terminalRef.current = null;
+      historyCompletionRef.current = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;
     };
@@ -645,6 +753,7 @@ function TerminalView({
     requestAnimationFrame(() => {
       try {
         fitAddon.fit();
+        historyCompletionRef.current?.refresh();
       } catch {
         // The terminal can be hidden while another tab is active.
       }

--- a/src/config-database.test.ts
+++ b/src/config-database.test.ts
@@ -27,13 +27,14 @@ describe("migrateLegacyConfiguration", () => {
       "2026-07-22T00:00:00.000Z",
     );
 
-    expect(configuration.schemaVersion).toBe(17);
+    expect(configuration.schemaVersion).toBe(18);
     expect(configuration.proxies).toEqual([]);
     expect(configuration.sshKeys).toEqual([]);
     expect(configuration.quickCommands).toEqual([]);
     expect(configuration.hostSort).toBe("manual");
     expect(configuration.sftpLocations).toEqual([]);
     expect(configuration.knownHosts).toEqual([]);
+    expect(configuration.terminalCommandHistory).toEqual([]);
     expect(configuration.credentialReferences).toEqual([]);
     expect(configuration.settings).toEqual(DEFAULT_APP_SETTINGS);
     expect(configuration.updatedAt).toBe("2026-07-22T00:00:00.000Z");
@@ -240,6 +241,7 @@ describe("configuration import and export", () => {
     expect(contents).toContain('"quickCommands"');
     expect(contents).toContain('"sftpLocations"');
     expect(contents).toContain('"knownHosts"');
+    expect(contents).not.toContain("terminalCommandHistory");
     expect(contents).not.toContain("credentialReferences");
     expect(contents).not.toContain("must-not-be-exported");
     expect(contents).not.toContain("key-passphrase-must-not-be-exported");

--- a/src/config-database.ts
+++ b/src/config-database.ts
@@ -16,6 +16,7 @@ import type {
   RemotePortForwardRule,
   SftpLocationRecord,
   SshKeyRecord,
+  TerminalCommandHistoryRecord,
 } from "./models";
 import {
   deriveKnownHostRecords,
@@ -31,6 +32,10 @@ import {
 } from "./ssh-keys";
 import { applyConnectionHistoryPolicy } from "./connection-history";
 import {
+  applyTerminalCommandHistoryPolicy,
+  sanitizeTerminalCommandHistoryRecord,
+} from "./terminal-command-history";
+import {
   sanitizeCredentialReference,
   type CredentialReferenceRecord,
 } from "./credential-registry";
@@ -42,7 +47,7 @@ const CONFIGURATION_ID = "primary";
 const HOSTS_STORAGE_KEY = "fineshell.hosts";
 const HISTORY_STORAGE_KEY = "fineshell.connection-history";
 
-export const CONFIGURATION_SCHEMA_VERSION = 17;
+export const CONFIGURATION_SCHEMA_VERSION = 18;
 export const CONFIGURATION_EXPORT_VERSION = 15;
 export const MAX_CONFIGURATION_BACKUPS = 10;
 export const TRASH_RETENTION_DAYS = 30;
@@ -82,6 +87,7 @@ export interface FineShellConfiguration {
   hostSort: HostSortMode;
   sftpLocations: SftpLocationRecord[];
   knownHosts: KnownHostRecord[];
+  terminalCommandHistory: TerminalCommandHistoryRecord[];
   settings: AppSettings;
   credentialReferences: CredentialReferenceRecord[];
   backups: ConfigurationBackup[];
@@ -584,6 +590,7 @@ export function migrateLegacyConfiguration(
     hostSort: "manual",
     sftpLocations: [],
     knownHosts: deriveKnownHostRecords(hosts, history, now),
+    terminalCommandHistory: [],
     settings: { ...DEFAULT_APP_SETTINGS },
     credentialReferences: [],
     backups: [],
@@ -622,6 +629,12 @@ function normalizeConfiguration(value: unknown): FineShellConfiguration {
     knownHosts: Array.isArray(value.knownHosts)
       ? sanitizeKnownHosts(value.knownHosts)
       : deriveKnownHostRecords(hosts, history, updatedAt),
+    terminalCommandHistory: applyTerminalCommandHistoryPolicy(
+      sanitizeList(
+        value.terminalCommandHistory,
+        sanitizeTerminalCommandHistoryRecord,
+      ),
+    ),
     settings,
     credentialReferences: sanitizeList(
       value.credentialReferences,

--- a/src/configuration-mutations.ts
+++ b/src/configuration-mutations.ts
@@ -31,6 +31,7 @@ import type {
   SftpLocationRecord,
   SshKeyRecord,
 } from "./models";
+import { recordTerminalCommand as recordTerminalCommandInHistory } from "./terminal-command-history";
 
 export function replaceConfigurationContent(
   hosts: HostRecord[],
@@ -232,6 +233,11 @@ export function permanentlyDeleteHost(deletedHostId: string) {
       sftpLocations: hostId
         ? current.sftpLocations.filter((item) => item.hostId !== hostId)
         : current.sftpLocations,
+      terminalCommandHistory: hostId
+        ? current.terminalCommandHistory.filter(
+            (item) => item.hostId !== hostId,
+          )
+        : current.terminalCommandHistory,
       trash: current.trash.filter((item) => item.id !== deletedHostId),
     };
   });
@@ -250,6 +256,9 @@ export async function purgeExpiredDeletedHosts(now = new Date()) {
     return {
       ...current,
       sftpLocations: current.sftpLocations.filter(
+        (item) => !expiredHostIds.includes(item.hostId),
+      ),
+      terminalCommandHistory: current.terminalCommandHistory.filter(
         (item) => !expiredHostIds.includes(item.hostId),
       ),
       trash,
@@ -376,6 +385,27 @@ export function updateAppSettings(settings: AppSettings) {
 
 export function clearConnectionHistory() {
   return updateConfiguration((current) => ({ ...current, history: [] }));
+}
+
+export function recordTerminalCommandHistory(
+  hostId: string,
+  command: string,
+  cwd?: string,
+) {
+  return updateConfiguration((current) => ({
+    ...current,
+    terminalCommandHistory: recordTerminalCommandInHistory(
+      current.terminalCommandHistory,
+      { hostId, command, cwd },
+    ),
+  }));
+}
+
+export function clearTerminalCommandHistory() {
+  return updateConfiguration((current) => ({
+    ...current,
+    terminalCommandHistory: [],
+  }));
 }
 
 export function upsertCredentialReference(

--- a/src/models.ts
+++ b/src/models.ts
@@ -165,6 +165,15 @@ export interface ConnectionHistoryRecord extends QuickTarget {
   connectedAt: string;
 }
 
+export interface TerminalCommandHistoryRecord {
+  id: string;
+  hostId: string;
+  command: string;
+  cwd?: string;
+  lastUsedAt: string;
+  useCount: number;
+}
+
 export interface JumpHostConnection {
   host: HostRecord;
   proxy?: ProxyRecord;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -247,13 +247,17 @@
 .terminal-view .xterm {
   height: 100%;
   padding: 8px 0 4px 8px;
-  background: var(--terminal-background, #191b20);
+  background-color: var(--terminal-background, #191b20) !important;
 }
 
 .terminal-view .xterm-viewport {
   overflow: hidden;
-  background-color: var(--terminal-background, #191b20);
+  background-color: var(--terminal-background, #191b20) !important;
   scrollbar-width: none;
+}
+
+.terminal-view .xterm-screen {
+  background-color: var(--terminal-background, #191b20);
 }
 
 .terminal-view .xterm-viewport::-webkit-scrollbar {

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -293,6 +293,11 @@
   border-radius: 3px;
 }
 
+.terminal-history-completion {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .terminal-search-bar {
   position: absolute;
   top: 8px;

--- a/src/terminal-command-history.test.ts
+++ b/src/terminal-command-history.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import type { TerminalCommandHistoryRecord } from "./models";
+import {
+  applyTerminalCommandHistoryPolicy,
+  findTerminalHistoryCompletion,
+  MAX_TERMINAL_COMMAND_HISTORY_PER_HOST,
+  recordTerminalCommand,
+  sanitizeTerminalCommandHistoryRecord,
+} from "./terminal-command-history";
+
+function historyRecord(
+  overrides: Partial<TerminalCommandHistoryRecord> = {},
+): TerminalCommandHistoryRecord {
+  return {
+    id: "history-1",
+    hostId: "host-1",
+    command: "git status",
+    cwd: "/srv/app",
+    lastUsedAt: "2026-08-04T00:00:00.000Z",
+    useCount: 1,
+    ...overrides,
+  };
+}
+
+describe("terminal command history policy", () => {
+  test("records repeated commands once and updates usage metadata", () => {
+    const first = recordTerminalCommand(
+      [],
+      { hostId: "host-1", command: "git status", cwd: "/srv/app" },
+      new Date("2026-08-04T00:00:00.000Z"),
+    );
+    const second = recordTerminalCommand(
+      first,
+      { hostId: "host-1", command: "git status", cwd: "/srv/api" },
+      new Date("2026-08-04T01:00:00.000Z"),
+    );
+
+    expect(second).toHaveLength(1);
+    expect(second[0]).toMatchObject({
+      hostId: "host-1",
+      command: "git status",
+      cwd: "/srv/api",
+      lastUsedAt: "2026-08-04T01:00:00.000Z",
+      useCount: 2,
+    });
+  });
+
+  test("rejects terminal controls and malformed persisted records", () => {
+    expect(
+      sanitizeTerminalCommandHistoryRecord(
+        historyRecord({ command: "echo ok\nrm -rf /" }),
+      ),
+    ).toBeUndefined();
+    expect(
+      recordTerminalCommand(
+        [],
+        { hostId: "host-1", command: "echo ok\u001b[A" },
+        new Date("2026-08-04T00:00:00.000Z"),
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps only the newest entries within each host limit", () => {
+    const records = Array.from(
+      { length: MAX_TERMINAL_COMMAND_HISTORY_PER_HOST + 2 },
+      (_, index) =>
+        historyRecord({
+          id: `history-${index}`,
+          command: `echo ${index}`,
+          lastUsedAt: new Date(index).toISOString(),
+        }),
+    );
+
+    const limited = applyTerminalCommandHistoryPolicy(records);
+    expect(limited).toHaveLength(MAX_TERMINAL_COMMAND_HISTORY_PER_HOST);
+    expect(limited[0].command).toBe(
+      `echo ${MAX_TERMINAL_COMMAND_HISTORY_PER_HOST + 1}`,
+    );
+    expect(limited[limited.length - 1]?.command).toBe("echo 2");
+  });
+});
+
+describe("terminal history completion", () => {
+  test("prefers the current directory before global usage count", () => {
+    const completion = findTerminalHistoryCompletion(
+      [
+        historyRecord({
+          id: "global",
+          command: "git status --short",
+          cwd: "/srv/other",
+          useCount: 20,
+        }),
+        historyRecord({
+          id: "local",
+          command: "git status --branch",
+          cwd: "/srv/app",
+          useCount: 1,
+        }),
+      ],
+      { hostId: "host-1", commandLine: "git st", cwd: "/srv/app" },
+    );
+
+    expect(completion).toEqual({
+      command: "git status --branch",
+      suffix: "atus --branch",
+    });
+  });
+
+  test("requires two characters and never suggests an exact command", () => {
+    const records = [historyRecord()];
+    expect(
+      findTerminalHistoryCompletion(records, {
+        hostId: "host-1",
+        commandLine: "g",
+      }),
+    ).toBeUndefined();
+    expect(
+      findTerminalHistoryCompletion(records, {
+        hostId: "host-1",
+        commandLine: "git status",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("does not expose history from another host", () => {
+    expect(
+      findTerminalHistoryCompletion([historyRecord()], {
+        hostId: "host-2",
+        commandLine: "git st",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/terminal-command-history.ts
+++ b/src/terminal-command-history.ts
@@ -1,0 +1,139 @@
+import type { TerminalCommandHistoryRecord } from "./models";
+
+export const MAX_TERMINAL_COMMAND_HISTORY_PER_HOST = 500;
+export const MAX_TERMINAL_COMMAND_HISTORY_TOTAL = 5_000;
+export const MAX_TERMINAL_COMMAND_CHARS = 4_096;
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function validDate(value: unknown) {
+  const date = nonEmptyString(value);
+  return date && Number.isFinite(Date.parse(date)) ? date : undefined;
+}
+
+export function sanitizeTerminalCommandHistoryRecord(
+  value: unknown,
+): TerminalCommandHistoryRecord | undefined {
+  if (!isRecord(value)) return undefined;
+  const id = nonEmptyString(value.id);
+  const hostId = nonEmptyString(value.hostId);
+  const command = nonEmptyString(value.command);
+  const lastUsedAt = validDate(value.lastUsedAt);
+  if (
+    !id ||
+    !hostId ||
+    !command ||
+    !lastUsedAt ||
+    command.length > MAX_TERMINAL_COMMAND_CHARS ||
+    /[\u0000-\u0008\u000a-\u001f\u007f]/u.test(command)
+  ) {
+    return undefined;
+  }
+  const cwd = nonEmptyString(value.cwd);
+  const useCount =
+    typeof value.useCount === "number" &&
+    Number.isSafeInteger(value.useCount) &&
+    value.useCount > 0
+      ? Math.min(value.useCount, Number.MAX_SAFE_INTEGER)
+      : 1;
+  return {
+    id,
+    hostId,
+    command,
+    ...(cwd && cwd.startsWith("/") && cwd.length <= 4_096 ? { cwd } : {}),
+    lastUsedAt,
+    useCount,
+  };
+}
+
+export function applyTerminalCommandHistoryPolicy(
+  records: readonly TerminalCommandHistoryRecord[],
+) {
+  const unique = new Map<string, TerminalCommandHistoryRecord>();
+  const perHost = new Map<string, number>();
+  const sorted = [...records]
+    .map(sanitizeTerminalCommandHistoryRecord)
+    .filter((record): record is TerminalCommandHistoryRecord => Boolean(record))
+    .sort(
+      (left, right) =>
+        Date.parse(right.lastUsedAt) - Date.parse(left.lastUsedAt),
+    );
+
+  for (const record of sorted) {
+    const key = `${record.hostId}\u0000${record.command}`;
+    if (unique.has(key)) continue;
+    const hostCount = perHost.get(record.hostId) ?? 0;
+    if (hostCount >= MAX_TERMINAL_COMMAND_HISTORY_PER_HOST) continue;
+    unique.set(key, record);
+    perHost.set(record.hostId, hostCount + 1);
+    if (unique.size >= MAX_TERMINAL_COMMAND_HISTORY_TOTAL) break;
+  }
+  return [...unique.values()];
+}
+
+export function recordTerminalCommand(
+  records: readonly TerminalCommandHistoryRecord[],
+  input: { hostId: string; command: string; cwd?: string },
+  now = new Date(),
+) {
+  const hostId = input.hostId.trim();
+  const command = input.command.trim();
+  if (
+    !hostId ||
+    !command ||
+    command.length > MAX_TERMINAL_COMMAND_CHARS ||
+    /[\u0000-\u001f\u007f]/u.test(command)
+  ) {
+    return applyTerminalCommandHistoryPolicy(records);
+  }
+
+  const existing = records.find(
+    (record) => record.hostId === hostId && record.command === command,
+  );
+  const next: TerminalCommandHistoryRecord = {
+    id:
+      existing?.id ??
+      `terminal-history-${now.getTime()}-${Math.random().toString(36).slice(2, 8)}`,
+    hostId,
+    command,
+    ...(input.cwd?.startsWith("/") ? { cwd: input.cwd.slice(0, 4_096) } : {}),
+    lastUsedAt: now.toISOString(),
+    useCount: Math.min((existing?.useCount ?? 0) + 1, Number.MAX_SAFE_INTEGER),
+  };
+  return applyTerminalCommandHistoryPolicy([
+    next,
+    ...records.filter((record) => record.id !== existing?.id),
+  ]);
+}
+
+export function findTerminalHistoryCompletion(
+  records: readonly TerminalCommandHistoryRecord[],
+  input: { hostId: string; commandLine: string; cwd?: string },
+) {
+  if (input.commandLine.trim().length < 2) return undefined;
+  const candidates = records.filter(
+    (record) =>
+      record.hostId === input.hostId &&
+      record.command !== input.commandLine &&
+      record.command.startsWith(input.commandLine),
+  );
+  candidates.sort((left, right) => {
+    const leftDirectory = input.cwd && left.cwd === input.cwd ? 1 : 0;
+    const rightDirectory = input.cwd && right.cwd === input.cwd ? 1 : 0;
+    if (leftDirectory !== rightDirectory) return rightDirectory - leftDirectory;
+    if (left.useCount !== right.useCount) return right.useCount - left.useCount;
+    return Date.parse(right.lastUsedAt) - Date.parse(left.lastUsedAt);
+  });
+  const command = candidates[0]?.command;
+  return command
+    ? { command, suffix: command.slice(input.commandLine.length) }
+    : undefined;
+}

--- a/src/terminal-font-zoom.test.ts
+++ b/src/terminal-font-zoom.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_TERMINAL_FONT_SIZE,
+  MIN_TERMINAL_FONT_SIZE,
+  nextTerminalFontSizeOffset,
+  terminalFontSize,
+  terminalFontZoomKeyboardAction,
+  terminalFontZoomWheelAction,
+} from "./terminal-font-zoom";
+
+describe("terminal font zoom", () => {
+  test("clamps the temporary size without changing the configured base", () => {
+    expect(terminalFontSize(13, 2)).toBe(15);
+    expect(terminalFontSize(13, -99)).toBe(MIN_TERMINAL_FONT_SIZE);
+    expect(terminalFontSize(13, 99)).toBe(MAX_TERMINAL_FONT_SIZE);
+    expect(nextTerminalFontSizeOffset(13, 3, "reset")).toBe(0);
+  });
+
+  test("increments one pixel and remains inside the supported range", () => {
+    expect(nextTerminalFontSizeOffset(13, 0, "increase")).toBe(1);
+    expect(nextTerminalFontSizeOffset(13, 0, "decrease")).toBe(-1);
+    expect(nextTerminalFontSizeOffset(24, 4, "increase")).toBe(4);
+    expect(nextTerminalFontSizeOffset(10, -1, "decrease")).toBe(-1);
+  });
+
+  test("uses Command on Apple platforms and Ctrl elsewhere", () => {
+    expect(
+      terminalFontZoomKeyboardAction(
+        { altKey: false, code: "Equal", ctrlKey: false, metaKey: true },
+        "MacIntel",
+      ),
+    ).toBe("increase");
+    expect(
+      terminalFontZoomKeyboardAction(
+        { altKey: false, code: "Minus", ctrlKey: true, metaKey: false },
+        "Win32",
+      ),
+    ).toBe("decrease");
+    expect(
+      terminalFontZoomKeyboardAction(
+        { altKey: false, code: "Digit0", ctrlKey: true, metaKey: false },
+        "Linux x86_64",
+      ),
+    ).toBe("reset");
+    expect(
+      terminalFontZoomKeyboardAction(
+        { altKey: false, code: "Equal", ctrlKey: true, metaKey: false },
+        "MacIntel",
+      ),
+    ).toBeUndefined();
+    expect(
+      terminalFontZoomKeyboardAction(
+        {
+          altKey: false,
+          code: "Equal",
+          ctrlKey: false,
+          metaKey: true,
+          type: "keyup",
+        },
+        "MacIntel",
+      ),
+    ).toBeUndefined();
+  });
+
+  test("maps primary-modifier wheel direction to zoom actions", () => {
+    expect(
+      terminalFontZoomWheelAction(
+        { altKey: false, ctrlKey: false, deltaY: -10, metaKey: true },
+        "MacIntel",
+      ),
+    ).toBe("increase");
+    expect(
+      terminalFontZoomWheelAction(
+        { altKey: false, ctrlKey: true, deltaY: 10, metaKey: false },
+        "Win32",
+      ),
+    ).toBe("decrease");
+    expect(
+      terminalFontZoomWheelAction(
+        { altKey: false, ctrlKey: false, deltaY: 10, metaKey: false },
+        "Win32",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/terminal-font-zoom.ts
+++ b/src/terminal-font-zoom.ts
@@ -1,0 +1,76 @@
+import { isApplePlatform } from "./platform-utils";
+
+export type TerminalFontZoomAction = "decrease" | "increase" | "reset";
+
+export const MIN_TERMINAL_FONT_SIZE = 9;
+export const MAX_TERMINAL_FONT_SIZE = 28;
+
+interface PrimaryModifierEvent {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+interface TerminalFontZoomKeyboardEvent extends PrimaryModifierEvent {
+  code: string;
+  type?: string;
+}
+
+interface TerminalFontZoomWheelEvent extends PrimaryModifierEvent {
+  deltaY: number;
+}
+
+function hasPrimaryModifier(event: PrimaryModifierEvent, platform: string) {
+  return isApplePlatform(platform) ? event.metaKey : event.ctrlKey;
+}
+
+export function terminalFontSize(baseSize: number, offset: number) {
+  return Math.min(
+    MAX_TERMINAL_FONT_SIZE,
+    Math.max(MIN_TERMINAL_FONT_SIZE, Math.round(baseSize + offset)),
+  );
+}
+
+export function nextTerminalFontSizeOffset(
+  baseSize: number,
+  currentOffset: number,
+  action: TerminalFontZoomAction,
+) {
+  if (action === "reset") return 0;
+  const currentSize = terminalFontSize(baseSize, currentOffset);
+  const delta = action === "increase" ? 1 : -1;
+  return terminalFontSize(currentSize, delta) - baseSize;
+}
+
+export function terminalFontZoomKeyboardAction(
+  event: TerminalFontZoomKeyboardEvent,
+  platform: string = navigator.platform,
+): TerminalFontZoomAction | undefined {
+  if (
+    (event.type && event.type !== "keydown") ||
+    event.altKey ||
+    !hasPrimaryModifier(event, platform)
+  ) {
+    return undefined;
+  }
+  if (event.code === "Equal" || event.code === "NumpadAdd") return "increase";
+  if (event.code === "Minus" || event.code === "NumpadSubtract") {
+    return "decrease";
+  }
+  if (event.code === "Digit0" || event.code === "Numpad0") return "reset";
+  return undefined;
+}
+
+export function terminalFontZoomWheelAction(
+  event: TerminalFontZoomWheelEvent,
+  platform: string = navigator.platform,
+): TerminalFontZoomAction | undefined {
+  if (
+    event.altKey ||
+    !hasPrimaryModifier(event, platform) ||
+    event.deltaY === 0
+  ) {
+    return undefined;
+  }
+  return event.deltaY < 0 ? "increase" : "decrease";
+}

--- a/src/terminal-history-completion.test.ts
+++ b/src/terminal-history-completion.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import type { IDecoration, IDisposable, IMarker, Terminal } from "@xterm/xterm";
+import type { TerminalCommandHistoryRecord } from "./models";
+import { TerminalHistoryCompletionAddon } from "./terminal-history-completion";
+
+function disposable(onDispose = () => undefined): IDisposable {
+  return { dispose: onDispose };
+}
+
+function keyboardEvent(key: string) {
+  let prevented = false;
+  let stopped = false;
+  return {
+    event: {
+      altKey: false,
+      ctrlKey: false,
+      key,
+      metaKey: false,
+      preventDefault: () => {
+        prevented = true;
+      },
+      shiftKey: false,
+      stopPropagation: () => {
+        stopped = true;
+      },
+      type: "keydown",
+    } as unknown as KeyboardEvent,
+    prevented: () => prevented,
+    stopped: () => stopped,
+  };
+}
+
+function fakeTerminal() {
+  const callbacks: { resize?: () => void; writeParsed?: () => void } = {};
+  const classes = new Set<string>();
+  const element = {
+    classList: { add: (value: string) => classes.add(value) },
+    style: {} as Record<string, string>,
+    textContent: "",
+  } as unknown as HTMLElement;
+  const marker = {
+    dispose: () => undefined,
+    id: 1,
+    isDisposed: false,
+    line: 0,
+    onDispose: () => disposable(),
+  } as unknown as IMarker;
+  const decoration = {
+    dispose: () => undefined,
+    element,
+    marker,
+    onRender: (listener: (element: HTMLElement) => void) => {
+      listener(element);
+      return disposable();
+    },
+  } as unknown as IDecoration;
+  const active = { cursorX: 4, type: "normal" };
+  let decorationOptions: unknown;
+  const terminal = {
+    buffer: { active },
+    cols: 80,
+    onResize: (listener: () => void) => {
+      callbacks.resize = listener;
+      return disposable();
+    },
+    onWriteParsed: (listener: () => void) => {
+      callbacks.writeParsed = listener;
+      return disposable();
+    },
+    options: {
+      allowProposedApi: true,
+      fontFamily: '"JetBrains Mono", monospace',
+      fontSize: 14,
+      fontWeight: 500,
+      letterSpacing: 1,
+      lineHeight: 1.2,
+    },
+    registerDecoration: (options: unknown) => {
+      decorationOptions = options;
+      return decoration;
+    },
+    registerMarker: () => marker,
+  } as unknown as Terminal;
+  return {
+    active,
+    callbacks,
+    classes,
+    decorationOptions: () => decorationOptions,
+    element,
+    terminal,
+  };
+}
+
+const HISTORY: TerminalCommandHistoryRecord[] = [
+  {
+    id: "history-1",
+    hostId: "host-1",
+    command: "git status --short",
+    cwd: "/srv/app",
+    lastUsedAt: "2026-08-04T00:00:00.000Z",
+    useCount: 2,
+  },
+];
+
+describe("TerminalHistoryCompletionAddon", () => {
+  test("renders a suggestion at the cursor and accepts only its suffix", () => {
+    const accepted: string[] = [];
+    const fake = fakeTerminal();
+    const addon = new TerminalHistoryCompletionAddon({
+      hostId: "host-1",
+      getCurrentDirectory: () => "/srv/app",
+      onAccept: (suffix) => accepted.push(suffix),
+    });
+    addon.activate(fake.terminal);
+    addon.setHistory(HISTORY);
+    addon.setPromptReady(true);
+    addon.synchronizeInput("git st", true);
+    fake.callbacks.writeParsed?.();
+
+    expect(addon.suggestion).toBe("atus --short");
+    expect(fake.decorationOptions()).toMatchObject({ x: 4, layer: "top" });
+    expect(fake.element.textContent).toBe("atus --short");
+    expect(fake.classes.has("terminal-history-completion")).toBe(true);
+    expect(fake.element.style.fontFamily).toBe(
+      '"JetBrains Mono", monospace',
+    );
+    expect(fake.element.style.fontSize).toBe("14px");
+    expect(fake.element.style.fontWeight).toBe("500");
+    expect(fake.element.style.letterSpacing).toBe("1px");
+    expect(fake.element.style.lineHeight).toBe("1.2");
+
+    const tab = keyboardEvent("Tab");
+    expect(addon.handleKeyEvent(tab.event)).toBe(false);
+    expect(tab.prevented()).toBe(true);
+    expect(tab.stopped()).toBe(true);
+    expect(accepted).toEqual(["atus --short"]);
+    expect(addon.suggestion).toBeUndefined();
+  });
+
+  test("leaves native Tab untouched when there is no suggestion", () => {
+    const fake = fakeTerminal();
+    const addon = new TerminalHistoryCompletionAddon({
+      hostId: "host-1",
+      getCurrentDirectory: () => "/srv/app",
+      onAccept: () => undefined,
+    });
+    addon.activate(fake.terminal);
+    addon.setPromptReady(true);
+    addon.synchronizeInput("unknown", true);
+
+    const tab = keyboardEvent("Tab");
+    expect(addon.handleKeyEvent(tab.event)).toBe(true);
+    expect(tab.prevented()).toBe(false);
+  });
+
+  test("cancels with Escape and hides suggestions in alternate buffers", () => {
+    const fake = fakeTerminal();
+    const addon = new TerminalHistoryCompletionAddon({
+      hostId: "host-1",
+      getCurrentDirectory: () => "/srv/app",
+      onAccept: () => undefined,
+    });
+    addon.activate(fake.terminal);
+    addon.setHistory(HISTORY);
+    addon.setPromptReady(true);
+    addon.synchronizeInput("git st", true);
+
+    const escape = keyboardEvent("Escape");
+    expect(addon.handleKeyEvent(escape.event)).toBe(false);
+    expect(addon.suggestion).toBeUndefined();
+
+    fake.active.type = "alternate";
+    addon.synchronizeInput("git st", true);
+    expect(addon.suggestion).toBeUndefined();
+  });
+});

--- a/src/terminal-history-completion.ts
+++ b/src/terminal-history-completion.ts
@@ -1,0 +1,258 @@
+import type {
+  IDecoration,
+  IDisposable,
+  IMarker,
+  ITerminalAddon,
+  Terminal,
+} from "@xterm/xterm";
+import type { TerminalCommandHistoryRecord } from "./models";
+import { findTerminalHistoryCompletion } from "./terminal-command-history";
+
+export interface TerminalHistoryCompletionOptions {
+  hostId: string;
+  getCurrentDirectory: () => string | undefined;
+  onAccept: (suffix: string) => void;
+  ghostTextColor?: string;
+}
+
+export class TerminalHistoryCompletionAddon implements ITerminalAddon {
+  private terminal?: Terminal;
+  private history: readonly TerminalCommandHistoryRecord[] = [];
+  private commandLine = "";
+  private inputReliable = true;
+  private promptReady = false;
+  private suggestionValue?: string;
+  private decoration?: IDecoration;
+  private decorationRenderDisposable?: IDisposable;
+  private marker?: IMarker;
+  private readonly disposables: IDisposable[] = [];
+
+  public constructor(
+    private readonly options: TerminalHistoryCompletionOptions,
+  ) {}
+
+  public get suggestion() {
+    return this.suggestionValue;
+  }
+
+  public activate(terminal: Terminal) {
+    if (this.terminal) {
+      throw new Error("TerminalHistoryCompletionAddon is already active");
+    }
+    if (!terminal.options.allowProposedApi) {
+      throw new Error(
+        "TerminalHistoryCompletionAddon requires allowProposedApi for decorations",
+      );
+    }
+    this.terminal = terminal;
+    this.disposables.push(
+      terminal.onWriteParsed(() => this.refreshDecoration()),
+      terminal.onResize(() => this.refreshDecoration()),
+    );
+  }
+
+  public setHistory(history: readonly TerminalCommandHistoryRecord[]) {
+    this.history = history;
+    this.updateSuggestion();
+    this.refreshDecoration();
+  }
+
+  public setPromptReady(ready: boolean) {
+    this.promptReady = ready;
+    this.updateSuggestion();
+    if (!ready) this.clearVisual();
+  }
+
+  public refresh() {
+    this.updateSuggestion();
+    this.refreshDecoration();
+  }
+
+  public synchronizeInput(commandLine: string, reliable: boolean) {
+    this.commandLine = commandLine;
+    this.inputReliable = reliable;
+    this.updateSuggestion();
+    this.clearVisual();
+  }
+
+  public handleKeyEvent(event: KeyboardEvent) {
+    if (
+      event.type !== "keydown" ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return true;
+    }
+    if (event.key === "Tab" && this.suggestionValue) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.accept();
+      return false;
+    }
+    if (event.key === "Escape" && this.suggestionValue) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.cancel();
+      return false;
+    }
+    return true;
+  }
+
+  public accept() {
+    const suffix = this.suggestionValue;
+    if (!suffix) return undefined;
+    this.commandLine += suffix;
+    this.suggestionValue = undefined;
+    this.clearVisual();
+    this.options.onAccept(suffix);
+    return suffix;
+  }
+
+  public cancel() {
+    this.suggestionValue = undefined;
+    this.clearVisual();
+  }
+
+  public dispose() {
+    this.cancel();
+    for (const disposable of this.disposables.splice(0)) disposable.dispose();
+    this.terminal = undefined;
+  }
+
+  private updateSuggestion() {
+    const terminal = this.terminal;
+    if (
+      !terminal ||
+      !this.promptReady ||
+      !this.inputReliable ||
+      terminal.buffer.active.type === "alternate"
+    ) {
+      this.suggestionValue = undefined;
+      return;
+    }
+    this.suggestionValue = findTerminalHistoryCompletion(this.history, {
+      hostId: this.options.hostId,
+      commandLine: this.commandLine,
+      cwd: this.options.getCurrentDirectory(),
+    })?.suffix;
+  }
+
+  private refreshDecoration() {
+    const terminal = this.terminal;
+    const suggestion = this.suggestionValue;
+    this.clearVisual();
+    if (
+      !terminal ||
+      !suggestion ||
+      !this.promptReady ||
+      terminal.buffer.active.type === "alternate"
+    ) {
+      return;
+    }
+
+    const cursorX = terminal.buffer.active.cursorX;
+    const fitted = fitGhostText(
+      suggestion,
+      Math.max(1, terminal.cols - cursorX),
+    );
+    if (!fitted.text) return;
+    const marker = terminal.registerMarker(0);
+    const decoration = terminal.registerDecoration({
+      marker,
+      x: cursorX,
+      width: fitted.width,
+      layer: "top",
+    });
+    if (!decoration) {
+      marker.dispose();
+      return;
+    }
+    const render = (element: HTMLElement) => {
+      const fontSize = terminal.options.fontSize ?? 15;
+      element.classList.add("terminal-history-completion");
+      element.textContent = fitted.text;
+      element.style.color = this.options.ghostTextColor ?? "#86909c";
+      element.style.fontFamily = terminal.options.fontFamily ?? "monospace";
+      element.style.fontSize = `${fontSize}px`;
+      element.style.fontWeight = String(
+        terminal.options.fontWeight ?? "normal",
+      );
+      element.style.fontVariantLigatures = "none";
+      element.style.letterSpacing = `${terminal.options.letterSpacing ?? 0}px`;
+      element.style.lineHeight = String(terminal.options.lineHeight ?? 1);
+      element.style.opacity = "0.78";
+      element.style.overflow = "visible";
+      element.style.pointerEvents = "none";
+      element.style.whiteSpace = "pre";
+      element.style.zIndex = "3";
+    };
+    this.marker = marker;
+    this.decoration = decoration;
+    this.decorationRenderDisposable = decoration.onRender(render);
+    if (decoration.element) render(decoration.element);
+  }
+
+  private clearVisual() {
+    this.decorationRenderDisposable?.dispose();
+    this.decorationRenderDisposable = undefined;
+    this.decoration?.dispose();
+    this.decoration = undefined;
+    this.marker?.dispose();
+    this.marker = undefined;
+  }
+}
+
+function characterCellWidth(character: string) {
+  if (/\p{Mark}/u.test(character)) return 0;
+  const codePoint = character.codePointAt(0) ?? 0;
+  if (
+    /\p{Extended_Pictographic}/u.test(character) ||
+    (codePoint >= 0x1100 &&
+      (codePoint <= 0x115f ||
+        codePoint === 0x2329 ||
+        codePoint === 0x232a ||
+        (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
+        (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+        (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+        (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+        (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+        (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+        (codePoint >= 0xffe0 && codePoint <= 0xffe6)))
+  ) {
+    return 2;
+  }
+  return 1;
+}
+
+function textCellWidth(value: string) {
+  return Array.from(value).reduce(
+    (width, character) => width + characterCellWidth(character),
+    0,
+  );
+}
+
+function takeCells(value: string, limit: number) {
+  let width = 0;
+  let text = "";
+  for (const character of Array.from(value)) {
+    const characterWidth = characterCellWidth(character);
+    if (width + characterWidth > limit) break;
+    text += character;
+    width += characterWidth;
+  }
+  return { text, width };
+}
+
+function fitGhostText(value: string, availableCells: number) {
+  const width = textCellWidth(value);
+  if (width <= availableCells)
+    return { text: value, width: Math.max(1, width) };
+  if (availableCells <= 3) {
+    const text = ".".repeat(availableCells);
+    return { text, width: availableCells };
+  }
+  const prefix = takeCells(value, availableCells - 3);
+  return { text: `${prefix.text}...`, width: prefix.width + 3 };
+}


### PR DESCRIPTION
## 变更内容

- 基于本地主机命令历史提供终端 Ghost Text 自动补全，支持 Tab 接受与 Esc 取消
- 支持使用 Command/Ctrl 配合 `+`、`-`、`0` 或鼠标滚轮临时调整终端字号
- 缩放后自动重新适配终端画布与远端 PTY 行列
- 补充快捷键说明，并统一 Ghost Text 与终端字体
- 修复终端上、左、下边缘背景颜色不一致的问题

## 用户影响

终端输入可复用历史命令，字号能够在当前主窗口内快速调整，不会修改持久化设置或缩放整个页面。

## 验证

- `bun test`：374 项通过
- `bun run build`：通过
