### PR TITLE
修复终端边框并优化标题栏交互

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,9 +84,7 @@ import { useTerminalSessions } from "./hooks/useTerminalSessions";
 const ServerMonitorPanel = lazy(
   () => import("./components/ServerMonitorPanel"),
 );
-const AiAssistantPanel = lazy(
-  () => import("./components/AiAssistantPanel"),
-);
+const AiAssistantPanel = lazy(() => import("./components/AiAssistantPanel"));
 const TerminalView = lazy(() => import("./components/TerminalView"));
 
 function createId(prefix: string) {
@@ -191,9 +189,7 @@ function App() {
       recordDiagnostic(
         "warn",
         "application.window",
-        operation === "expand"
-          ? "AI 侧栏窗口扩宽失败"
-          : "AI 侧栏窗口还原失败",
+        operation === "expand" ? "AI 侧栏窗口扩宽失败" : "AI 侧栏窗口还原失败",
         { error: commandErrorMessage(error) },
       );
       Message.warning(
@@ -482,7 +478,7 @@ function App() {
   useEffect(() => {
     if (!activeSessionId) {
       setQuickCommandDrawerVisible(false);
-      closeAiAssistant();
+      closeAiSidebar();
       return;
     }
     const handleQuickCommandShortcut = (event: KeyboardEvent) => {
@@ -500,13 +496,10 @@ function App() {
     window.addEventListener("keydown", handleQuickCommandShortcut, true);
     return () =>
       window.removeEventListener("keydown", handleQuickCommandShortcut, true);
-  }, [activeSessionId]);
+  }, [activeSessionId, closeAiSidebar]);
 
   async function sendQuickCommand(command: string, execute: boolean) {
-    if (
-      !activeSession ||
-      !isTerminalSessionOperational(activeSession.status)
-    ) {
+    if (!activeSession || !isTerminalSessionOperational(activeSession.status)) {
       throw new Error("当前终端未连接");
     }
     const input = execute ? `${command}\r` : command;
@@ -518,10 +511,7 @@ function App() {
     Message.success(execute ? "命令已发送" : "命令已填入终端");
   }
 
-  function handleAiCommandPrepared(
-    sessionId: string,
-    command: string,
-  ) {
+  function handleAiCommandPrepared(sessionId: string, command: string) {
     setTerminalInjectedInputs((current) => ({
       ...current,
       [sessionId]: {
@@ -601,10 +591,6 @@ function App() {
       };
     });
     await openAiAssistant(request.prompt, [request.source.id]);
-  }
-
-  function closeAiAssistant() {
-    closeAiSidebar();
   }
 
   function toggleAiAssistant() {
@@ -701,11 +687,14 @@ function App() {
     <section className="panel terminal-panel">
       <SessionTabs
         activeSessionId={activeSessionId}
+        aiAssistantVisible={aiAssistantActive}
+        hasActiveSession={Boolean(activeSession)}
         homeContent={
           <HostManagerPanel onConnect={openSession} settings={settings} />
         }
         onActiveSessionChange={setActiveSessionId}
         onCloseSession={closeSession}
+        onToggleAiAssistant={toggleAiAssistant}
         renderSession={(session) => (
           <Suspense fallback={null}>
             <TerminalView
@@ -828,7 +817,6 @@ function App() {
         initialPrompt={aiInitialPrompt}
         initialContextIds={aiInitialContextIds}
         initialPromptRequest={aiInitialPromptRequest}
-        onClose={closeAiAssistant}
         onAgentActionExecuted={handleAiAgentActionExecuted}
         onCommandPrepared={handleAiCommandPrepared}
         onRemoveRemoteFile={(sessionId, path) =>
@@ -858,7 +846,6 @@ function App() {
     <AppWorkspaceLayout
       applicationTitleBar={
         <ApplicationTitleBar
-          aiAssistantVisible={aiAssistantActive}
           hasActiveSession={Boolean(activeSession)}
           onOpenQuickCommands={() => setQuickCommandDrawerVisible(true)}
           onOpenSettings={() => openAuxiliaryWindow("settings")}
@@ -867,7 +854,6 @@ function App() {
             setServerMonitorCollapsed((collapsed) => !collapsed)
           }
           onToggleSftp={() => setSftpCollapsed((collapsed) => !collapsed)}
-          onToggleAiAssistant={toggleAiAssistant}
           serverMonitorCollapsed={serverMonitorCollapsed}
           sftpCollapsed={sftpCollapsed}
         />

--- a/src/components/AiAssistantPanel.tsx
+++ b/src/components/AiAssistantPanel.tsx
@@ -77,15 +77,11 @@ interface AiAssistantPanelProps {
   initialContextIds: AiContextSourceId[];
   initialPrompt: string;
   initialPromptRequest: number;
-  onClose: () => void;
   onAgentActionExecuted: (
     sessionId: string,
     result: AgentActionExecutionResult,
   ) => void;
-  onCommandPrepared: (
-    sessionId: string,
-    command: string,
-  ) => void;
+  onCommandPrepared: (sessionId: string, command: string) => void;
   onRemoveRemoteFile: (sessionId: string, path: string) => void;
   remoteFiles: AiRemoteFileContext[];
   sessionId: string | null;
@@ -102,7 +98,6 @@ function AiAssistantPanel({
   initialContextIds,
   initialPrompt,
   initialPromptRequest,
-  onClose,
   onAgentActionExecuted,
   onCommandPrepared,
   onRemoveRemoteFile,
@@ -319,7 +314,13 @@ function AiAssistantPanel({
           ? activeTask.plan?.id
           : undefined,
       ),
-    [activeTask?.id, activeTask?.plan?.id, activeTask?.status, messages, sending],
+    [
+      activeTask?.id,
+      activeTask?.plan?.id,
+      activeTask?.status,
+      messages,
+      sending,
+    ],
   );
   const queuedApproval = approvalQueue[0];
   const queuedApprovalId = queuedApproval
@@ -790,14 +791,10 @@ function AiAssistantPanel({
     feedback: string,
   ) => {
     if (!feedback.trim()) return;
-    await rejectCommandAndResume(
-      messageId,
-      proposal.id,
-      {
-        feedback: feedback.trim(),
-        kind: "revision_requested",
-      },
-    );
+    await rejectCommandAndResume(messageId, proposal.id, {
+      feedback: feedback.trim(),
+      kind: "revision_requested",
+    });
   };
 
   const retry = (assistantIndex: number) => {
@@ -842,20 +839,15 @@ function AiAssistantPanel({
     });
   };
 
-  const closePanel = () => {
-    onClose();
-  };
-
   return (
     <aside className="panel ai-assistant-sidebar-panel">
       <AiAssistantHeader
         approvalMode={approvalMode}
         canInsertCommand={canInsertCommand}
-        conversationAvailable={Boolean(activeConversation)}
         conversationSummarized={Boolean(activeConversation?.summary)}
         conversationSummarizing={Boolean(
           activeConversation &&
-            summarizingConversationIds.has(activeConversation.id),
+          summarizingConversationIds.has(activeConversation.id),
         )}
         conversationTitle={activeConversation?.title ?? ""}
         disconnectedError={
@@ -864,10 +856,6 @@ function AiAssistantPanel({
             : undefined
         }
         onApprovalModeChange={setApprovalMode}
-        onClose={closePanel}
-        onDelete={() =>
-          activeConversation && removeConversation(activeConversation.id)
-        }
         onNew={newConversation}
         onOpenHistory={openHistory}
         sending={sending}
@@ -921,10 +909,7 @@ function AiAssistantPanel({
           sessionId={sessionId}
         />
         {activeApproval && (
-          <section
-            aria-label="AI 操作审批"
-            className="ai-approval-dock"
-          >
+          <section aria-label="AI 操作审批" className="ai-approval-dock">
             {activeApproval.kind === "command" ? (
               <AiCommandProposalList
                 canInsertCommand={canInsertCommand}

--- a/src/components/AppWorkspaceLayout.tsx
+++ b/src/components/AppWorkspaceLayout.tsx
@@ -129,12 +129,18 @@ export default function AppWorkspaceLayout({
           directions={["left"]}
           onMoving={(_, size) => {
             const workspaceWidth =
-              mainSplitRef.current?.parentElement?.getBoundingClientRect().width ??
-              window.innerWidth;
-            onAiSidebarWidthChange(clampAiSidebarWidth(size.width, workspaceWidth));
+              mainSplitRef.current?.parentElement?.getBoundingClientRect()
+                .width ?? window.innerWidth;
+            onAiSidebarWidthChange(
+              clampAiSidebarWidth(size.width, workspaceWidth),
+            );
           }}
-          onMovingEnd={() => document.body.classList.remove("ai-sidebar-resizing")}
-          onMovingStart={() => document.body.classList.add("ai-sidebar-resizing")}
+          onMovingEnd={() =>
+            document.body.classList.remove("ai-sidebar-resizing")
+          }
+          onMovingStart={() =>
+            document.body.classList.add("ai-sidebar-resizing")
+          }
           width={aiSidebarWidth}
         >
           {aiAssistantPanel}

--- a/src/components/ApplicationTitleBar.test.tsx
+++ b/src/components/ApplicationTitleBar.test.tsx
@@ -4,7 +4,6 @@ import { primaryShortcutModifier } from "../platform-utils";
 import ApplicationTitleBar from "./ApplicationTitleBar";
 
 function renderTitleBar({
-  aiAssistantVisible = false,
   hasActiveSession = true,
   platform = "Win32",
   serverMonitorCollapsed = false,
@@ -15,7 +14,6 @@ function renderTitleBar({
   const onOpenShortcutGuide = mock(() => undefined);
   const onToggleServerMonitor = mock(() => undefined);
   const onToggleSftp = mock(() => undefined);
-  const onToggleAiAssistant = mock(() => undefined);
 
   return {
     onOpenQuickCommands,
@@ -23,17 +21,14 @@ function renderTitleBar({
     onOpenShortcutGuide,
     onToggleServerMonitor,
     onToggleSftp,
-    onToggleAiAssistant,
     ...render(
       <ApplicationTitleBar
-        aiAssistantVisible={aiAssistantVisible}
         hasActiveSession={hasActiveSession}
         onOpenQuickCommands={onOpenQuickCommands}
         onOpenSettings={onOpenSettings}
         onOpenShortcutGuide={onOpenShortcutGuide}
         onToggleServerMonitor={onToggleServerMonitor}
         onToggleSftp={onToggleSftp}
-        onToggleAiAssistant={onToggleAiAssistant}
         platform={platform}
         serverMonitorCollapsed={serverMonitorCollapsed}
         sftpCollapsed={sftpCollapsed}
@@ -49,21 +44,22 @@ describe("ApplicationTitleBar", () => {
     expect(primaryShortcutModifier("Linux x86_64")).toBe("Ctrl");
   });
 
-  test("keeps application actions immediately before custom window controls", () => {
+  test("keeps one application menu immediately before custom window controls", () => {
     const {
       container,
       onOpenQuickCommands,
       onOpenSettings,
       onOpenShortcutGuide,
-      onToggleAiAssistant,
     } = renderTitleBar();
+    const menuButton = screen.getByRole("button", { name: "打开应用菜单" });
 
-    fireEvent.click(screen.getByRole("button", { name: "打开 AI 助手" }));
-    fireEvent.click(screen.getByRole("button", { name: "打开快捷命令" }));
-    fireEvent.click(screen.getByRole("button", { name: "打开快捷键与操作" }));
-    fireEvent.click(screen.getByRole("button", { name: "打开设置" }));
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByText("快捷命令"));
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByText("快捷键"));
+    fireEvent.click(menuButton);
+    fireEvent.click(screen.getByText("设置"));
 
-    expect(onToggleAiAssistant).toHaveBeenCalledTimes(1);
     expect(onOpenQuickCommands).toHaveBeenCalledTimes(1);
     expect(onOpenShortcutGuide).toHaveBeenCalledTimes(1);
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
@@ -71,8 +67,12 @@ describe("ApplicationTitleBar", () => {
     expect(screen.getByRole("button", { name: "最大化窗口" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "关闭窗口" })).toBeTruthy();
     expect(
-      container.querySelector(".application-titlebar-toolbar")?.nextElementSibling
-        ?.classList.contains("application-window-controls"),
+      container.querySelectorAll(".application-titlebar-toolbar button"),
+    ).toHaveLength(3);
+    expect(
+      container
+        .querySelector(".application-titlebar-toolbar")
+        ?.nextElementSibling?.classList.contains("application-window-controls"),
     ).toBe(true);
   });
 
@@ -82,34 +82,26 @@ describe("ApplicationTitleBar", () => {
     expect(screen.queryByRole("button", { name: "最小化窗口" })).toBeNull();
     expect(screen.queryByRole("button", { name: "最大化窗口" })).toBeNull();
     expect(screen.queryByRole("button", { name: "关闭窗口" })).toBeNull();
-    expect(screen.getByRole("button", { name: "打开设置" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "打开应用菜单" })).toBeTruthy();
   });
 
   test("disables session actions without an active terminal", () => {
-    renderTitleBar({ hasActiveSession: false });
-
-    expect(
-      (screen.getByRole("button", { name: "打开 AI 助手" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
-    expect(
-      (screen.getByRole("button", { name: "打开快捷命令" }) as HTMLButtonElement)
-        .disabled,
-    ).toBe(true);
-  });
-
-  test("exposes the AI action as a close toggle while visible", () => {
-    const { onToggleAiAssistant } = renderTitleBar({
-      aiAssistantVisible: true,
+    const { onOpenQuickCommands } = renderTitleBar({
+      hasActiveSession: false,
     });
-    const button = screen.getByRole("button", { name: "关闭 AI 助手" });
+    fireEvent.click(screen.getByRole("button", { name: "打开应用菜单" }));
+    const quickCommandItem = screen
+      .getByText("快捷命令")
+      .closest(".arco-dropdown-menu-item");
 
-    expect(button.getAttribute("aria-pressed")).toBe("true");
-    fireEvent.click(button);
-    expect(onToggleAiAssistant).toHaveBeenCalledTimes(1);
+    expect(
+      quickCommandItem?.classList.contains("arco-dropdown-menu-disabled"),
+    ).toBe(true);
+    fireEvent.click(quickCommandItem!);
+    expect(onOpenQuickCommands).not.toHaveBeenCalled();
   });
 
-  test("toggles the monitor and SFTP panels before the settings action", () => {
+  test("keeps panel toggles before the application menu", () => {
     const { container, onToggleServerMonitor, onToggleSftp } = renderTitleBar();
     const monitorButton = screen.getByRole("button", {
       name: "隐藏服务器监控",
@@ -121,22 +113,21 @@ describe("ApplicationTitleBar", () => {
       ),
     );
 
-    expect(monitorButton.querySelector(".lucide-panel-left-close")).toBeTruthy();
-    expect(sftpButton.querySelector(".lucide-panel-bottom-close")).toBeTruthy();
-    expect(
-      toolbarButtons[toolbarButtons.length - 3]?.getAttribute("aria-label"),
-    ).toBe("隐藏服务器监控");
-    expect(
-      toolbarButtons[toolbarButtons.length - 2]?.getAttribute("aria-label"),
-    ).toBe("隐藏文件管理");
-    expect(
-      toolbarButtons[toolbarButtons.length - 1]?.getAttribute("aria-label"),
-    ).toBe("打开设置");
-
     fireEvent.click(monitorButton);
     fireEvent.click(sftpButton);
     expect(onToggleServerMonitor).toHaveBeenCalledTimes(1);
     expect(onToggleSftp).toHaveBeenCalledTimes(1);
+    expect(
+      toolbarButtons.map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["隐藏服务器监控", "隐藏文件管理", "打开应用菜单"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "打开应用菜单" }));
+    const items = Array.from(
+      document.querySelectorAll(
+        ".application-titlebar-menu .arco-dropdown-menu-item",
+      ),
+    );
+    expect(items[items.length - 1]?.textContent).toContain("设置");
   });
 
   test("shows only the matching open icons while panels are hidden", () => {

--- a/src/components/ApplicationTitleBar.tsx
+++ b/src/components/ApplicationTitleBar.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useState } from "react";
-import { Button, Message, Tooltip } from "@arco-design/web-react";
+import {
+  Button,
+  Dropdown,
+  Menu as ArcoMenu,
+  Message,
+  Tooltip,
+} from "@arco-design/web-react";
 import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
-  Bot,
   CircleHelp,
   Command,
   Maximize,
+  Menu,
   Minimize,
   Minus,
   PanelBottomClose,
@@ -16,17 +22,15 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import { isApplePlatform, primaryShortcutModifier } from "../platform-utils";
+import { isApplePlatform } from "../platform-utils";
 
 interface ApplicationTitleBarProps {
-  aiAssistantVisible: boolean;
   hasActiveSession: boolean;
   onOpenQuickCommands: () => void;
   onOpenSettings: () => void;
   onOpenShortcutGuide: () => void;
   onToggleServerMonitor: () => void;
   onToggleSftp: () => void;
-  onToggleAiAssistant: () => void;
   platform?: string;
   serverMonitorCollapsed: boolean;
   sftpCollapsed: boolean;
@@ -38,21 +42,18 @@ function reportWindowOperationError(error: unknown) {
 }
 
 export default function ApplicationTitleBar({
-  aiAssistantVisible,
   hasActiveSession,
   onOpenQuickCommands,
   onOpenSettings,
   onOpenShortcutGuide,
   onToggleServerMonitor,
   onToggleSftp,
-  onToggleAiAssistant,
   platform = navigator.platform,
   serverMonitorCollapsed,
   sftpCollapsed,
 }: ApplicationTitleBarProps) {
   const applePlatform = isApplePlatform(platform);
   const [maximized, setMaximized] = useState(false);
-  const primaryModifier = primaryShortcutModifier(platform);
 
   useEffect(() => {
     if (applePlatform || !isTauri()) return;
@@ -122,58 +123,6 @@ export default function ApplicationTitleBar({
 
       <div className="application-titlebar-toolbar">
         <Tooltip
-          content={
-            hasActiveSession
-              ? aiAssistantVisible
-                ? "关闭 AI 助手"
-                : "打开 AI 助手"
-              : "请先打开终端会话"
-          }
-        >
-          <span className="application-titlebar-action-wrapper">
-            <Button
-              aria-label={aiAssistantVisible ? "关闭 AI 助手" : "打开 AI 助手"}
-              aria-pressed={aiAssistantVisible}
-              className={`application-titlebar-action-button${
-                aiAssistantVisible ? " is-active" : ""
-              }`}
-              disabled={!hasActiveSession}
-              icon={<Bot aria-hidden="true" />}
-              onClick={onToggleAiAssistant}
-              type="text"
-            />
-          </span>
-        </Tooltip>
-        <Tooltip
-          content={
-            hasActiveSession
-              ? `快捷命令（${primaryModifier} + Shift + P）`
-              : "请先打开终端会话"
-          }
-        >
-          <span className="application-titlebar-action-wrapper">
-            <Button
-              aria-label="打开快捷命令"
-              className="application-titlebar-action-button"
-              disabled={!hasActiveSession}
-              icon={<Command aria-hidden="true" />}
-              onClick={onOpenQuickCommands}
-              type="text"
-            />
-          </span>
-        </Tooltip>
-        <Tooltip content="快捷键与操作">
-          <span className="application-titlebar-action-wrapper">
-            <Button
-              aria-label="打开快捷键与操作"
-              className="application-titlebar-action-button"
-              icon={<CircleHelp aria-hidden="true" />}
-              onClick={onOpenShortcutGuide}
-              type="text"
-            />
-          </span>
-        </Tooltip>
-        <Tooltip
           content={serverMonitorCollapsed ? "显示服务器监控" : "隐藏服务器监控"}
         >
           <span className="application-titlebar-action-wrapper">
@@ -213,17 +162,53 @@ export default function ApplicationTitleBar({
             />
           </span>
         </Tooltip>
-        <Tooltip content={`设置（${primaryModifier} + ,）`}>
-          <span className="application-titlebar-action-wrapper">
-            <Button
-              aria-label="打开设置"
-              className="application-titlebar-action-button"
-              icon={<Settings aria-hidden="true" />}
-              onClick={onOpenSettings}
-              type="text"
-            />
-          </span>
-        </Tooltip>
+        <span className="application-titlebar-action-wrapper">
+          <Dropdown
+            droplist={
+              <ArcoMenu
+                className="application-titlebar-menu"
+                onClickMenuItem={(key) => {
+                  if (key === "quickCommands") onOpenQuickCommands();
+                  else if (key === "shortcutGuide") onOpenShortcutGuide();
+                  else if (key === "settings") onOpenSettings();
+                }}
+              >
+                <ArcoMenu.Item disabled={!hasActiveSession} key="quickCommands">
+                  <span className="application-titlebar-menu-label">
+                    <Command aria-hidden="true" />
+                    <span>快捷命令</span>
+                  </span>
+                </ArcoMenu.Item>
+                <ArcoMenu.Item key="shortcutGuide">
+                  <span className="application-titlebar-menu-label">
+                    <CircleHelp aria-hidden="true" />
+                    <span>快捷键</span>
+                  </span>
+                </ArcoMenu.Item>
+                <ArcoMenu.Item
+                  className="application-titlebar-menu-settings"
+                  key="settings"
+                >
+                  <span className="application-titlebar-menu-label">
+                    <Settings aria-hidden="true" />
+                    <span>设置</span>
+                  </span>
+                </ArcoMenu.Item>
+              </ArcoMenu>
+            }
+            position="br"
+            trigger="click"
+          >
+            <Tooltip content="菜单">
+              <Button
+                aria-label="打开应用菜单"
+                className="application-titlebar-action-button"
+                icon={<Menu aria-hidden="true" />}
+                type="text"
+              />
+            </Tooltip>
+          </Dropdown>
+        </span>
       </div>
 
       {!applePlatform && (

--- a/src/components/SessionTabs.test.tsx
+++ b/src/components/SessionTabs.test.tsx
@@ -26,15 +26,21 @@ const SESSION: TerminalSession = {
 function renderTabs(
   activeSessionId: string | null,
   onActiveSessionChange = mock(() => undefined),
+  aiAssistantVisible = false,
 ) {
+  const onToggleAiAssistant = mock(() => undefined);
   return {
     onActiveSessionChange,
+    onToggleAiAssistant,
     ...render(
       <SessionTabs
         activeSessionId={activeSessionId}
+        aiAssistantVisible={aiAssistantVisible}
+        hasActiveSession={activeSessionId !== null}
         homeContent={<div>主机管理内容</div>}
         onActiveSessionChange={onActiveSessionChange}
         onCloseSession={() => undefined}
+        onToggleAiAssistant={onToggleAiAssistant}
         renderSession={(session) => <div>终端 {session.host.name}</div>}
         sessionContextMenuItems={() => []}
         sessions={[SESSION]}
@@ -63,5 +69,32 @@ describe("SessionTabs", () => {
 
     fireEvent.click(container.querySelector(".terminal-home-tab")!);
     expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  test("keeps the AI toggle fixed outside the scrollable tabs", () => {
+    const { container, onToggleAiAssistant } = renderTabs(
+      "session-1",
+      undefined,
+      true,
+    );
+    const button = screen.getByRole("button", { name: "关闭 AI 助手" });
+
+    expect(container.querySelector(".terminal-tabs")?.contains(button)).toBe(
+      false,
+    );
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(button);
+    expect(onToggleAiAssistant).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables the AI toggle on the fixed home page", () => {
+    renderTabs(null);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "打开 AI 助手",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
   });
 });

--- a/src/components/SessionTabs.tsx
+++ b/src/components/SessionTabs.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
-import { Tabs, Tooltip } from "@arco-design/web-react";
+import { Button, Tabs, Tooltip } from "@arco-design/web-react";
 import { IconHome } from "@arco-design/web-react/icon";
+import { Bot } from "lucide-react";
 import type { TerminalSession } from "../models";
 import { sessionTabName } from "../terminal-utils";
 import ContextMenu, { type ContextMenuItem } from "./ContextMenu";
@@ -9,9 +10,12 @@ const HOME_TAB_ID = "home";
 
 interface SessionTabsProps {
   activeSessionId: string | null;
+  aiAssistantVisible: boolean;
+  hasActiveSession: boolean;
   homeContent: ReactNode;
   onActiveSessionChange: (sessionId: string | null) => void;
   onCloseSession: (sessionId: string) => void;
+  onToggleAiAssistant: () => void;
   renderSession: (session: TerminalSession) => ReactNode;
   sessionContextMenuItems: (session: TerminalSession) => ContextMenuItem[];
   sessions: TerminalSession[];
@@ -33,9 +37,12 @@ function sessionStatusLabel(session: TerminalSession) {
 
 function SessionTabs({
   activeSessionId,
+  aiAssistantVisible,
+  hasActiveSession,
   homeContent,
   onActiveSessionChange,
   onCloseSession,
+  onToggleAiAssistant,
   renderSession,
   sessionContextMenuItems,
   sessions,
@@ -105,6 +112,23 @@ function SessionTabs({
           </Tabs.TabPane>
         ))}
       </Tabs>
+      <div className="terminal-ai-action">
+        <Tooltip content="AI">
+          <span>
+            <Button
+              aria-label={aiAssistantVisible ? "关闭 AI 助手" : "打开 AI 助手"}
+              aria-pressed={aiAssistantVisible}
+              className={`terminal-ai-action-button${
+                aiAssistantVisible ? " is-active" : ""
+              }`}
+              disabled={!hasActiveSession}
+              icon={<Bot aria-hidden="true" />}
+              onClick={onToggleAiAssistant}
+              type="text"
+            />
+          </span>
+        </Tooltip>
+      </div>
     </>
   );
 }

--- a/src/components/SettingsWindow.test.tsx
+++ b/src/components/SettingsWindow.test.tsx
@@ -20,6 +20,11 @@ describe("SettingsWindow", () => {
       "连接与安全",
       "数据与隐私",
     ]);
+    expect(
+      view.container.querySelectorAll(
+        ".settings-sidebar .arco-menu-icon-suffix.is-open",
+      ),
+    ).toHaveLength(0);
     const menuItems = Array.from(
       view.container.querySelectorAll(".settings-sidebar .arco-menu-item"),
     ).map((item) => item.textContent?.trim());
@@ -71,11 +76,13 @@ describe("SettingsWindow", () => {
       screen.getByLabelText("允许 AI 生成终端命令提案"),
     ).not.toBeNull();
 
+    await user.click(screen.getByText("连接与安全"));
     await user.click(screen.getByText("连接默认值"));
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: "连接默认值" })).not.toBeNull(),
     );
 
+    await user.click(screen.getByText("数据与隐私"));
     await user.click(screen.getByText("隐私与清理"));
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: "隐私与清理" })).not.toBeNull(),

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -639,7 +639,7 @@ function SettingsWindow() {
     <main className="settings-window">
       <aside className="settings-sidebar">
         <Menu
-          defaultOpenKeys={["general", "connectionSecurity", "dataPrivacy"]}
+          defaultOpenKeys={[]}
           onClickMenuItem={(key) =>
             updateInstalling && key !== "about"
               ? Message.warning("更新正在安装，请等待安装完成")

--- a/src/components/ai/AiAssistantHeader.test.tsx
+++ b/src/components/ai/AiAssistantHeader.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, mock, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import AiAssistantHeader from "./AiAssistantHeader";
+
+describe("AiAssistantHeader", () => {
+  test("keeps conversation creation and history without delete or close actions", () => {
+    render(
+      <AiAssistantHeader
+        approvalMode="on_request"
+        canInsertCommand
+        conversationSummarized={false}
+        conversationSummarizing={false}
+        conversationTitle="诊断会话"
+        onApprovalModeChange={mock(() => undefined)}
+        onNew={mock(() => undefined)}
+        onOpenHistory={mock(() => undefined)}
+        sending={false}
+        sessionAvailable
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "新建对话" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "对话历史" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "删除当前对话" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "关闭 AI 助手" })).toBeNull();
+  });
+});

--- a/src/components/ai/AiAssistantHeader.tsx
+++ b/src/components/ai/AiAssistantHeader.tsx
@@ -7,12 +7,7 @@ import {
   Tooltip,
   Typography,
 } from "@arco-design/web-react";
-import {
-  IconClose,
-  IconDelete,
-  IconHistory,
-  IconPlus,
-} from "@arco-design/web-react/icon";
+import { IconHistory, IconPlus } from "@arco-design/web-react/icon";
 import type { AgentApprovalMode } from "../../tauri-protocol";
 
 const AI_APPROVAL_MODE_OPTIONS = [
@@ -24,14 +19,11 @@ const AI_APPROVAL_MODE_OPTIONS = [
 interface AiAssistantHeaderProps {
   approvalMode: AgentApprovalMode;
   canInsertCommand: boolean;
-  conversationAvailable: boolean;
   conversationSummarized: boolean;
   conversationSummarizing: boolean;
   conversationTitle: string;
   disconnectedError?: string;
   onApprovalModeChange: (mode: AgentApprovalMode) => void;
-  onClose: () => void;
-  onDelete: () => void;
   onNew: () => void;
   onOpenHistory: () => void;
   sessionAvailable: boolean;
@@ -41,14 +33,11 @@ interface AiAssistantHeaderProps {
 export default function AiAssistantHeader({
   approvalMode,
   canInsertCommand,
-  conversationAvailable,
   conversationSummarized,
   conversationSummarizing,
   conversationTitle,
   disconnectedError,
   onApprovalModeChange,
-  onClose,
-  onDelete,
   onNew,
   onOpenHistory,
   sessionAvailable,
@@ -123,21 +112,6 @@ export default function AiAssistantHeader({
             type="text"
           />
         </Tooltip>
-        <Tooltip content="删除当前对话">
-          <Button
-            aria-label="删除当前对话"
-            disabled={!conversationAvailable || sending}
-            icon={<IconDelete />}
-            onClick={onDelete}
-            type="text"
-          />
-        </Tooltip>
-        <Button
-          aria-label="关闭 AI 助手"
-          icon={<IconClose />}
-          onClick={onClose}
-          type="text"
-        />
       </Space>
     </div>
   );

--- a/src/hooks/useAiSidebarController.ts
+++ b/src/hooks/useAiSidebarController.ts
@@ -15,10 +15,7 @@ export interface AiSidebarWindowAdapter {
 
 interface UseAiSidebarControllerOptions {
   getWorkspaceWidth: () => number | undefined;
-  onResizeFailure?: (
-    error: unknown,
-    operation: "expand" | "collapse",
-  ) => void;
+  onResizeFailure?: (error: unknown, operation: "expand" | "collapse") => void;
   sidebarWidth: number;
   windowAdapter?: AiSidebarWindowAdapter | null;
 }
@@ -140,15 +137,9 @@ export function useAiSidebarController({
             sidebarWidthRef.current,
           );
           await adapter.setInnerSize(targetWidth, before.height);
-          appliedExpansionRef.current = Math.max(
-            0,
-            targetWidth - before.width,
-          );
+          appliedExpansionRef.current = Math.max(0, targetWidth - before.width);
           const after = await adapter.getInnerSize();
-          appliedExpansionRef.current = Math.max(
-            0,
-            after.width - before.width,
-          );
+          appliedExpansionRef.current = Math.max(0, after.width - before.width);
           resizeFailureReportedRef.current = false;
         }
       } catch (error) {
@@ -218,35 +209,37 @@ export function useAiSidebarController({
     let disposed = false;
     let unlisten: (() => void) | undefined;
     let timer: number | undefined;
-    void adapter.onResized(() => {
-      if (
-        disposed ||
-        stateRef.current.phase !== "closed" ||
-        appliedExpansionRef.current <= 0
-      ) {
-        return;
-      }
-      window.clearTimeout(timer);
-      timer = window.setTimeout(() => {
-        void enqueue(async () => {
-          if (
-            disposed ||
-            stateRef.current.phase !== "closed" ||
-            appliedExpansionRef.current <= 0
-          ) {
-            return;
-          }
-          try {
-            await collapseWindow(adapter);
-          } catch (error) {
-            reportResizeFailure(error, "collapse");
-          }
-        });
-      }, 120);
-    }).then((dispose) => {
-      if (disposed) dispose();
-      else unlisten = dispose;
-    });
+    void adapter
+      .onResized(() => {
+        if (
+          disposed ||
+          stateRef.current.phase !== "closed" ||
+          appliedExpansionRef.current <= 0
+        ) {
+          return;
+        }
+        window.clearTimeout(timer);
+        timer = window.setTimeout(() => {
+          void enqueue(async () => {
+            if (
+              disposed ||
+              stateRef.current.phase !== "closed" ||
+              appliedExpansionRef.current <= 0
+            ) {
+              return;
+            }
+            try {
+              await collapseWindow(adapter);
+            } catch (error) {
+              reportResizeFailure(error, "collapse");
+            }
+          });
+        }, 120);
+      })
+      .then((dispose) => {
+        if (disposed) dispose();
+        else unlisten = dispose;
+      });
     return () => {
       disposed = true;
       window.clearTimeout(timer);

--- a/src/styles/app-base.css
+++ b/src/styles/app-base.css
@@ -254,6 +254,30 @@ code *,
   background: #e8f3ff;
 }
 
+.application-titlebar-menu {
+  min-width: 156px;
+  border: 1px solid #e5e6eb;
+  box-shadow: none;
+}
+
+.application-titlebar-menu-label {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+}
+
+.application-titlebar-menu-label .lucide {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+}
+
+.application-titlebar-menu-settings {
+  border-top: 1px solid #f2f3f5;
+}
+
 .application-window-control {
   width: 46px;
   height: 100%;
@@ -318,15 +342,13 @@ code *,
   overflow: hidden;
 }
 
-.main-split-left-collapsed
-  > .arco-resizebox-split-group-pane:first-child {
+.main-split-left-collapsed > .arco-resizebox-split-group-pane:first-child {
   display: none;
   flex-basis: 0 !important;
   min-width: 0;
 }
 
-.main-split-left-collapsed
-  > .arco-resizebox-split-group-pane:last-child {
+.main-split-left-collapsed > .arco-resizebox-split-group-pane:last-child {
   flex-basis: 100% !important;
 }
 
@@ -338,13 +360,11 @@ code *,
   width: 100%;
 }
 
-.right-split-sftp-collapsed
-  > .arco-resizebox-split-group-pane:first-child {
+.right-split-sftp-collapsed > .arco-resizebox-split-group-pane:first-child {
   flex-basis: 100% !important;
 }
 
-.right-split-sftp-collapsed
-  > .arco-resizebox-split-group-pane:last-child {
+.right-split-sftp-collapsed > .arco-resizebox-split-group-pane:last-child {
   display: none;
   flex-basis: 0 !important;
 }

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -1,4 +1,5 @@
 .terminal-panel {
+  --terminal-ai-action-width: 44px;
   --terminal-home-tab-width: 92px;
   --terminal-tab-height: 36px;
   position: relative;
@@ -62,7 +63,8 @@
   box-sizing: border-box;
   height: var(--terminal-tab-height);
   margin: 0;
-  padding: 0 8px 0 calc(8px + var(--terminal-home-tab-width));
+  padding: 0 calc(8px + var(--terminal-ai-action-width)) 0
+    calc(8px + var(--terminal-home-tab-width));
   background: #f2f2f2;
 }
 
@@ -173,6 +175,51 @@
 .terminal-tabs .arco-tabs-add-icon:hover {
   color: #165dff;
   background: #f2f3f5;
+}
+
+.terminal-ai-action {
+  position: absolute;
+  top: 3px;
+  right: 8px;
+  z-index: 3;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.terminal-ai-action > span,
+.terminal-ai-action-button.arco-btn {
+  width: 30px;
+  height: 30px;
+}
+
+.terminal-ai-action-button.arco-btn {
+  padding: 0;
+  color: #4e5969;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+}
+
+.terminal-ai-action-button.arco-btn:not(.arco-btn-disabled):hover {
+  color: #1d2129;
+  background: #e5e6eb;
+}
+
+.terminal-ai-action-button.arco-btn.is-active,
+.terminal-ai-action-button.arco-btn.is-active:hover {
+  color: #165dff;
+  background: #e8f3ff;
+}
+
+.terminal-ai-action-button svg {
+  width: 17px;
+  height: 17px;
+  stroke-width: 1.75;
 }
 
 .terminal-tab-label {

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -221,6 +221,7 @@
   flex: 1;
   min-height: 0;
   padding: 0;
+  border: 0;
 }
 
 .terminal-tabs .arco-tabs-content-inner,


### PR DESCRIPTION
## 变更内容

- 修复隐藏侧栏和文件管理后终端边缘出现白线的问题
- 将 AI 入口固定到终端标签栏右侧，支持切换面板显示
- 精简 AI 面板标题栏，将删除操作保留在对话历史中
- 使用应用菜单收纳快捷命令、快捷键与设置入口
- 保留服务器监控和文件管理的独立标题栏切换按钮
- 设置窗口的分组菜单默认折叠

## 影响

减少标题栏按钮密度，同时保留高频面板切换入口，并改善全屏终端和 AI 面板的操作一致性。

## 验证

- `bun test`：376 项通过
- `bun run build`：通过
- `git diff --check`：通过