### PR TITLE
重构 AI Agent 编排与工具协议

### DIFF
--- a/protocol/contract.json
+++ b/protocol/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": 32,
+  "version": 33,
   "commands": {
     "protocol_version": true,
     "open_settings_window": true,
@@ -26,6 +26,7 @@
     "ai_probe_capabilities": true,
     "ai_chat_start": true,
     "ai_chat_cancel": true,
+    "ai_task_action_results": true,
     "ai_task_get": true,
     "ai_task_events_since": true,
     "ai_task_recovery_decide": true,

--- a/protocol/contract.json
+++ b/protocol/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": 33,
+  "version": 34,
   "commands": {
     "protocol_version": true,
     "open_settings_window": true,
@@ -29,6 +29,7 @@
     "ai_task_action_results": true,
     "ai_task_get": true,
     "ai_task_events_since": true,
+    "ai_task_sync": true,
     "ai_task_recovery_decide": true,
     "ai_task_plan_decide": true,
     "ai_task_action_transition": true,

--- a/src-tauri/src/agent/commands.rs
+++ b/src-tauri/src/agent/commands.rs
@@ -39,6 +39,21 @@ pub(crate) fn ai_task_get(
 }
 
 #[tauri::command]
+pub(crate) fn ai_task_sync(
+    manager: State<'_, AgentTaskManager>,
+    task_id: String,
+    after_sequence: u64,
+) -> CommandResult<AgentTaskSync> {
+    let operation = "ai_task_sync";
+    if !valid_identifier(&task_id) {
+        return Err(CommandError::from_message(operation, "AI 任务标识无效"));
+    }
+    manager
+        .sync_task(&task_id, after_sequence)
+        .map_err(|error| CommandError::from_message(operation, error))
+}
+
+#[tauri::command]
 pub(crate) fn ai_task_recovery_decide(
     app: AppHandle,
     manager: State<'_, AgentTaskManager>,

--- a/src-tauri/src/agent/model.rs
+++ b/src-tauri/src/agent/model.rs
@@ -530,6 +530,13 @@ pub(crate) struct AgentTaskEvent {
     pub(super) task: AgentTask,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentTaskSync {
+    pub(super) task: Option<AgentTask>,
+    pub(super) events: Vec<AgentTaskEvent>,
+}
+
 pub(crate) struct AgentTaskManager {
     pub(super) tasks: Mutex<HashMap<String, AgentTask>>,
     pub(super) events: Mutex<HashMap<String, VecDeque<AgentTaskEvent>>>,

--- a/src-tauri/src/agent/model.rs
+++ b/src-tauri/src/agent/model.rs
@@ -284,6 +284,31 @@ pub(crate) struct AgentActionState {
     pub(super) command_submission_id: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct AgentActionResultSnapshot {
+    pub(crate) id: String,
+    pub(crate) tool: String,
+    pub(crate) status: AgentActionStatus,
+    pub(crate) summary: Option<String>,
+    pub(crate) error: Option<String>,
+    pub(crate) duration_ms: Option<u64>,
+    pub(crate) command: Option<AgentCommandResultSnapshot>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct AgentCommandResultSnapshot {
+    pub(crate) phase: AgentCommandExecutionPhase,
+    pub(crate) output: Option<String>,
+    pub(crate) output_truncated: bool,
+    pub(crate) stdout: Option<String>,
+    pub(crate) stdout_truncated: bool,
+    pub(crate) stderr: Option<String>,
+    pub(crate) stderr_truncated: bool,
+    pub(crate) exit_code: Option<u16>,
+    pub(crate) duration_ms: Option<u64>,
+    pub(crate) reason: Option<String>,
+}
+
 impl AgentActionState {
     pub(super) fn from_intent(intent: AgentActionIntent) -> Self {
         Self {

--- a/src-tauri/src/agent/persistence.rs
+++ b/src-tauri/src/agent/persistence.rs
@@ -187,6 +187,16 @@ impl AgentTaskManager {
             .cloned()
             .collect())
     }
+
+    pub(super) fn sync_task(
+        &self,
+        task_id: &str,
+        after_sequence: u64,
+    ) -> Result<AgentTaskSync, String> {
+        let task = self.get_task(task_id)?;
+        let events = self.events_since(task_id, after_sequence)?;
+        Ok(AgentTaskSync { task, events })
+    }
 }
 
 pub(crate) fn initialize(app: &AppHandle) -> Result<(), String> {

--- a/src-tauri/src/agent/task_state.rs
+++ b/src-tauri/src/agent/task_state.rs
@@ -208,4 +208,48 @@ impl AgentTaskManager {
         let tasks = self.lock_tasks()?;
         Ok(tasks.get(task_id).cloned())
     }
+
+    pub(crate) fn action_result_snapshot(
+        &self,
+        task_id: &str,
+        action_id: &str,
+    ) -> Result<AgentActionResultSnapshot, String> {
+        if !valid_identifier(task_id) || !valid_identifier(action_id) {
+            return Err("AI 动作作用域无效".to_string());
+        }
+        let tasks = self.lock_tasks()?;
+        let task = tasks
+            .get(task_id)
+            .ok_or_else(|| "AI 任务不存在".to_string())?;
+        let action = task
+            .actions
+            .iter()
+            .find(|action| action.id == action_id)
+            .ok_or_else(|| "AI 动作不存在".to_string())?;
+        let command =
+            action
+                .command_execution
+                .as_ref()
+                .map(|execution| AgentCommandResultSnapshot {
+                    phase: execution.phase,
+                    output: execution.output_excerpt.clone(),
+                    output_truncated: execution.output_truncated,
+                    stdout: execution.stdout_excerpt.clone(),
+                    stdout_truncated: execution.stdout_truncated,
+                    stderr: execution.stderr_excerpt.clone(),
+                    stderr_truncated: execution.stderr_truncated,
+                    exit_code: execution.exit_code,
+                    duration_ms: execution.duration_ms,
+                    reason: execution.reason.clone(),
+                });
+        Ok(AgentActionResultSnapshot {
+            id: action.id.clone(),
+            tool: action.tool.clone(),
+            status: action.status,
+            summary: action.summary.clone(),
+            error: action.error.clone(),
+            duration_ms: action.duration_ms,
+            command,
+        })
+    }
 }

--- a/src-tauri/src/agent/tests.rs
+++ b/src-tauri/src/agent/tests.rs
@@ -203,6 +203,9 @@ fn persists_only_redacted_snapshots_and_replays_bounded_events() {
             .collect::<Vec<_>>(),
         vec![2, 3]
     );
+    let sync = restored.sync_task("task-1", 1).unwrap();
+    assert_eq!(sync.task.unwrap().id, "task-1");
+    assert_eq!(sync.events.len(), 2);
     assert_eq!(
         restored.begin_model_turn(&task_context).unwrap_err(),
         "应用重启前的 AI 任务仅供查看，请发起新任务"

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -372,6 +372,23 @@ pub(crate) async fn ai_chat_start(
                 }
             }
 
+            if !response.pre_resolved_tool_results.is_empty() {
+                if let Some(context) = task_context.as_ref() {
+                    let events = task_manager
+                        .finish_model_turn(context.id(), true)
+                        .map_err(|error| structured(operation, error))?;
+                    agent::emit_task_events(&app, events);
+                }
+                tool_rounds.push(AiToolRound {
+                    calls: response.tool_calls.clone(),
+                    content: (!response.content.trim().is_empty())
+                        .then(|| response.content.trim().to_string()),
+                    reasoning_content: response.reasoning_content.clone(),
+                    results: std::mem::take(&mut response.pre_resolved_tool_results),
+                });
+                continue;
+            }
+
             if let Some(round) = invalid_tool_call_round(
                 &response.tool_calls,
                 &response.content,

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -1,5 +1,186 @@
 use super::*;
 
+fn bounded_round_message(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let value = value.trim().chars().take(500).collect::<String>();
+        (!value.is_empty()).then_some(value)
+    })
+}
+
+pub(super) fn action_round_result(
+    call: &AiToolCall,
+    decision: &AiActionRoundDecision,
+    snapshot: crate::agent::AgentActionResultSnapshot,
+) -> Result<AiToolResult, String> {
+    if snapshot.id != call.id {
+        return Err("AI 动作结果与工具调用不匹配".to_string());
+    }
+    let is_command = matches!(
+        call.name.as_str(),
+        "propose_terminal_command" | "propose_service_action"
+    );
+    if is_command != (snapshot.tool == "execute_terminal_command") {
+        return Err("AI 动作类型与工具调用不匹配".to_string());
+    }
+    let content = if decision.kind == AiActionRoundDecisionKind::RevisionRequested {
+        json!({
+            "ok": false,
+            "decision": "revision_requested",
+            "feedback": bounded_round_message(decision.feedback.clone()).unwrap_or_else(|| "请重新调整提案".to_string()),
+            "message": "用户拒绝了当前动作，并要求按反馈重新提案"
+        })
+    } else if decision.kind == AiActionRoundDecisionKind::Invalid {
+        json!({
+            "ok": false,
+            "decision": "invalid_proposal",
+            "error": bounded_round_message(decision.error.clone()).unwrap_or_else(|| "动作提案未通过客户端展示校验".to_string())
+        })
+    } else {
+        match snapshot.status {
+            AgentActionStatus::Rejected | AgentActionStatus::Cancelled => json!({
+                "ok": false,
+                "decision": "rejected",
+                "message": snapshot.summary.unwrap_or_else(|| "用户拒绝了当前动作，不得执行".to_string())
+            }),
+            AgentActionStatus::Succeeded if is_command => {
+                let command = snapshot
+                    .command
+                    .ok_or_else(|| "AI 命令缺少可信执行结果".to_string())?;
+                if command.phase != AgentCommandExecutionPhase::Completed {
+                    return Err("AI 命令成功状态与执行阶段不一致".to_string());
+                }
+                let exit_code = command
+                    .exit_code
+                    .ok_or_else(|| "AI 命令缺少退出码".to_string())?;
+                json!({
+                    "ok": exit_code == 0,
+                    "decision": "approved_and_completed",
+                    "durationMs": command.duration_ms.or(snapshot.duration_ms),
+                    "exitCode": exit_code,
+                    "output": command.output.as_deref().map(str::trim).filter(|value| !value.is_empty()),
+                    "outputTruncated": command.output_truncated.then_some(true),
+                    "stdout": command.stdout.as_deref().map(str::trim).filter(|value| !value.is_empty()),
+                    "stdoutTruncated": command.stdout_truncated.then_some(true),
+                    "stderr": command.stderr.as_deref().map(str::trim).filter(|value| !value.is_empty()),
+                    "stderrTruncated": command.stderr_truncated.then_some(true),
+                    "message": "命令已获批准，后台 SSH 执行器已完成执行"
+                })
+            }
+            AgentActionStatus::Failed if is_command => {
+                if let Some(command) = snapshot
+                    .command
+                    .as_ref()
+                    .filter(|command| command.exit_code.is_some())
+                {
+                    if command.phase != AgentCommandExecutionPhase::Failed {
+                        return Err("AI 命令失败状态与执行阶段不一致".to_string());
+                    }
+                    let exit_code = command.exit_code.unwrap_or_default();
+                    json!({
+                        "ok": false,
+                        "decision": "approved_and_completed",
+                        "durationMs": command.duration_ms.or(snapshot.duration_ms),
+                        "exitCode": exit_code,
+                        "output": command.output.as_deref().map(str::trim).filter(|value| !value.is_empty()),
+                        "outputTruncated": command.output_truncated.then_some(true),
+                        "stdout": command.stdout.as_deref().map(str::trim).filter(|value| !value.is_empty()),
+                        "stdoutTruncated": command.stdout_truncated.then_some(true),
+                        "stderr": command.stderr.as_deref().map(str::trim).filter(|value| !value.is_empty()),
+                        "stderrTruncated": command.stderr_truncated.then_some(true),
+                        "message": "命令已获批准，但后台执行返回非零退出码"
+                    })
+                } else {
+                    let reason = snapshot
+                        .command
+                        .and_then(|command| command.reason)
+                        .or(snapshot.error)
+                        .unwrap_or_else(|| "无法获取可靠的命令结束状态".to_string());
+                    json!({
+                        "ok": false,
+                        "decision": "execution_result_unavailable",
+                        "durationMs": snapshot.duration_ms,
+                        "error": reason,
+                        "message": "命令已获批准，但后台执行器未能返回可靠结果"
+                    })
+                }
+            }
+            AgentActionStatus::Succeeded => json!({
+                "ok": true,
+                "decision": "approved_and_completed",
+                "message": snapshot.summary.unwrap_or_else(|| "远程文件动作已完成".to_string())
+            }),
+            AgentActionStatus::Conflict | AgentActionStatus::Failed => json!({
+                "ok": false,
+                "decision": "execution_failed",
+                "error": snapshot.error.unwrap_or_else(|| "远程文件动作执行失败".to_string()),
+                "message": "文件动作已获批准，但执行失败"
+            }),
+            AgentActionStatus::Pending
+            | AgentActionStatus::Approved
+            | AgentActionStatus::Running
+            | AgentActionStatus::RollingBack => {
+                return Err("AI 动作尚未结束，不能进入下一轮模型调用".to_string());
+            }
+            AgentActionStatus::RolledBack
+            | AgentActionStatus::RollbackConflict
+            | AgentActionStatus::RollbackFailed => {
+                return Err("AI 动作处于回滚流程，不能作为当前提案结果".to_string());
+            }
+        }
+    };
+    Ok(AiToolResult {
+        call_id: call.id.clone(),
+        name: call.name.clone(),
+        content: content.to_string(),
+    })
+}
+
+#[tauri::command]
+pub(crate) fn ai_task_action_results(
+    app: AppHandle,
+    manager: State<'_, AgentTaskManager>,
+    request: AiActionRoundResolutionRequest,
+) -> CommandResult<Vec<AiToolResult>> {
+    let operation = "ai_task_action_results";
+    if request.calls.is_empty() || request.calls.len() != request.decisions.len() {
+        return Err(CommandError::from_message(
+            operation,
+            "AI 动作轮次结果不完整",
+        ));
+    }
+    let decisions = request
+        .decisions
+        .iter()
+        .map(|decision| (decision.call_id.as_str(), decision))
+        .collect::<HashMap<_, _>>();
+    request
+        .calls
+        .iter()
+        .map(|call| {
+            let decision = decisions
+                .get(call.id.as_str())
+                .ok_or_else(|| CommandError::from_message(operation, "AI 动作缺少用户决定"))?;
+            if decision.kind == AiActionRoundDecisionKind::Invalid {
+                let events = manager
+                    .transition_action(crate::agent::AgentActionTransitionRequest {
+                        task_id: request.task_id.clone(),
+                        action_id: call.id.clone(),
+                        transition: crate::agent::AgentActionTransition::Reject,
+                        summary: bounded_round_message(decision.error.clone()),
+                        error: None,
+                    })
+                    .map_err(|error| CommandError::from_message(operation, error))?;
+                agent::emit_task_events(&app, events);
+            }
+            let snapshot = manager
+                .action_result_snapshot(&request.task_id, &call.id)
+                .map_err(|error| CommandError::from_message(operation, error))?;
+            action_round_result(call, decision, snapshot)
+                .map_err(|error| CommandError::from_message(operation, error))
+        })
+        .collect()
+}
+
 #[tauri::command]
 pub(crate) async fn ai_list_models(request: AiModelsRequest) -> CommandResult<Vec<AiModelInfo>> {
     let operation = "ai_list_models";

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -7,6 +7,18 @@ fn bounded_round_message(value: Option<String>) -> Option<String> {
     })
 }
 
+pub(super) fn take_pre_resolved_tool_round(response: &mut AiChatResult) -> Option<AiToolRound> {
+    if response.pre_resolved_tool_results.is_empty() {
+        return None;
+    }
+    Some(AiToolRound {
+        calls: response.tool_calls.clone(),
+        content: (!response.content.trim().is_empty()).then(|| response.content.trim().to_string()),
+        reasoning_content: response.reasoning_content.clone(),
+        results: std::mem::take(&mut response.pre_resolved_tool_results),
+    })
+}
+
 pub(super) fn action_round_result(
     call: &AiToolCall,
     decision: &AiActionRoundDecision,
@@ -372,20 +384,14 @@ pub(crate) async fn ai_chat_start(
                 }
             }
 
-            if !response.pre_resolved_tool_results.is_empty() {
+            if let Some(round) = take_pre_resolved_tool_round(&mut response) {
                 if let Some(context) = task_context.as_ref() {
                     let events = task_manager
                         .finish_model_turn(context.id(), true)
                         .map_err(|error| structured(operation, error))?;
                     agent::emit_task_events(&app, events);
                 }
-                tool_rounds.push(AiToolRound {
-                    calls: response.tool_calls.clone(),
-                    content: (!response.content.trim().is_empty())
-                        .then(|| response.content.trim().to_string()),
-                    reasoning_content: response.reasoning_content.clone(),
-                    results: std::mem::take(&mut response.pre_resolved_tool_results),
-                });
+                tool_rounds.push(round);
                 continue;
             }
 

--- a/src-tauri/src/ai/diagnostics.rs
+++ b/src-tauri/src/ai/diagnostics.rs
@@ -1,17 +1,7 @@
 use super::*;
 
 pub(super) fn diagnostic_tool_label(name: &str) -> &'static str {
-    match name {
-        "get_server_status" => "读取服务器状态",
-        "list_processes" => "读取进程列表",
-        "get_current_directory" => "读取当前目录",
-        "inspect_service" => "检查服务状态",
-        "read_service_logs" => "读取服务日志",
-        "get_network_connections" => "读取网络连接",
-        "ping_target" => "Ping",
-        "trace_route" => "路由追踪",
-        _ => "未知只读工具",
-    }
+    tool_label(name).unwrap_or("未知只读工具")
 }
 
 pub(super) fn diagnostic_arguments(call: &AiToolCall) -> serde_json::Map<String, Value> {

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -135,6 +135,8 @@ pub(crate) struct AiChatResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_content: Option<String>,
     tool_calls: Vec<AiToolCall>,
+    #[serde(skip)]
+    pre_resolved_tool_results: Vec<AiToolResult>,
     action_intents: Vec<AgentActionIntent>,
     diagnostic_plans: Vec<AgentPlan>,
     diagnostic_tool_rounds: Vec<AiToolRound>,

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::Mutex,
+    sync::{LazyLock, Mutex},
     time::{Duration, Instant},
 };
 

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -14,8 +14,9 @@ use tokio::sync::watch;
 
 use crate::{
     agent::{
-        self, timestamp_ms, AgentActionIntent, AgentPlan, AgentPlanDecision, AgentPlanStatus,
-        AgentPlanStep, AgentPlanStepStatus, AgentTaskContext, AgentTaskManager,
+        self, timestamp_ms, AgentActionIntent, AgentActionStatus, AgentCommandExecutionPhase,
+        AgentPlan, AgentPlanDecision, AgentPlanStatus, AgentPlanStep, AgentPlanStepStatus,
+        AgentTaskContext, AgentTaskManager,
     },
     agent_actions::{
         normalize_remote_action_path, proposal_action_intent, MAX_COMMAND_PURPOSE_CHARS,
@@ -184,6 +185,34 @@ pub(crate) struct AiToolRound {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) reasoning_content: Option<String>,
     pub(crate) results: Vec<AiToolResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AiActionRoundResolutionRequest {
+    task_id: String,
+    calls: Vec<AiToolCall>,
+    decisions: Vec<AiActionRoundDecision>,
+}
+
+#[derive(Clone, Copy, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum AiActionRoundDecisionKind {
+    ExecutionCompleted,
+    ExecutionFailed,
+    ExecutionUnavailable,
+    Rejected,
+    RevisionRequested,
+    Invalid,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AiActionRoundDecision {
+    call_id: String,
+    kind: AiActionRoundDecisionKind,
+    feedback: Option<String>,
+    error: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src-tauri/src/ai/provider.rs
+++ b/src-tauri/src/ai/provider.rs
@@ -26,6 +26,7 @@ pub(super) struct ProviderTurnResult {
     pub(super) content: String,
     pub(super) reasoning_content: Option<String>,
     pub(super) tool_calls: Vec<AiToolCall>,
+    pub(super) pre_resolved_tool_results: Vec<AiToolResult>,
     pub(super) request_count: u32,
     pub(super) usage: Option<AiTokenUsage>,
 }
@@ -198,6 +199,7 @@ impl OpenAiCompatibleProvider {
             content: response.content,
             reasoning_content: response.reasoning_content,
             tool_calls: response.tool_calls,
+            pre_resolved_tool_results: response.pre_resolved_tool_results,
             request_count: response.request_count,
             usage: response.usage.map(|usage| AiTokenUsage {
                 input_tokens: usage.input_tokens,

--- a/src-tauri/src/ai/runtime.rs
+++ b/src-tauri/src/ai/runtime.rs
@@ -76,6 +76,7 @@ pub(super) async fn request_ai_turn(options: AiTurnOptions<'_>) -> CommandResult
     let content = response.content;
     let reasoning_content = response.reasoning_content;
     let tool_calls = response.tool_calls;
+    let pre_resolved_tool_results = response.pre_resolved_tool_results;
     if content.chars().count() > MAX_RESPONSE_CHARS {
         return Err(structured(operation, "AI 响应内容过长"));
     }
@@ -88,16 +89,6 @@ pub(super) async fn request_ai_turn(options: AiTurnOptions<'_>) -> CommandResult
     if options.finalize_reason.is_some() && !tool_calls.is_empty() {
         return Err(structured(operation, "AI 收尾响应不应包含工具调用"));
     }
-    if tool_calls.iter().any(|call| {
-        !tool_allowed(
-            &call.name,
-            options.tools_enabled,
-            options.file_edit_enabled,
-            options.command_proposal_enabled,
-        ) || (diagnostic_tool(&call.name) && !options.enabled_tools.contains(&call.name))
-    }) {
-        return Err(structured(operation, "AI 返回了未启用的工具调用"));
-    }
     if content.trim().is_empty() && tool_calls.is_empty() {
         return Err(structured(operation, "AI 服务没有返回内容"));
     }
@@ -105,6 +96,7 @@ pub(super) async fn request_ai_turn(options: AiTurnOptions<'_>) -> CommandResult
         content,
         reasoning_content,
         tool_calls,
+        pre_resolved_tool_results,
         action_intents: Vec::new(),
         diagnostic_plans: Vec::new(),
         diagnostic_tool_rounds: Vec::new(),

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -3,20 +3,102 @@ use std::collections::HashSet;
 use reqwest::Url;
 use serde_json::{json, Value};
 
-use crate::{agent::AgentTaskContext, agent_policy::PolicyDecision};
+use crate::{
+    agent::{
+        AgentActionResultSnapshot, AgentActionStatus, AgentCommandExecutionPhase,
+        AgentCommandResultSnapshot, AgentTaskContext,
+    },
+    agent_policy::PolicyDecision,
+};
 
 use super::{
-    apply_finalization_instruction, apply_tool_call_delta, build_request_messages,
-    capability_http_failure, complete_tool_calls, create_diagnostic_plan,
+    action_round_result, apply_finalization_instruction, apply_tool_call_delta,
+    build_request_messages, capability_http_failure, complete_tool_calls, create_diagnostic_plan,
     diagnostic_policy_evaluations, diagnostic_tool_requires_connection, enabled_diagnostic_tools,
     filter_tool_definitions, http_messages, invalid_tool_call_round, is_local_endpoint,
     is_tool_unsupported_error, normalize_models, sanitize_context, service_endpoint, stream_delta,
     stream_tool_call_deltas, tool_allowed, tool_definitions, tool_loop_finalize_reason,
     tool_probe_supported, valid_stream_probe_event, valid_tool_arguments,
     validate_diagnostic_plan_calls, validate_enabled_diagnostic_calls, validate_service_url,
-    validate_tool_rounds, AiCapabilityKind, AiCapabilityState, AiChatMessage, AiFinalizeReason,
-    AiModelEntry, AiToolCall, AiToolResult, AiToolRound, SseParser,
+    validate_tool_rounds, AiActionRoundDecision, AiActionRoundDecisionKind, AiCapabilityKind,
+    AiCapabilityState, AiChatMessage, AiFinalizeReason, AiModelEntry, AiToolCall, AiToolResult,
+    AiToolRound, SseParser,
 };
+
+#[test]
+fn action_round_result_uses_the_authoritative_command_snapshot() {
+    let call = AiToolCall {
+        id: "command-1".to_string(),
+        name: "propose_terminal_command".to_string(),
+        arguments: "{}".to_string(),
+    };
+    let decision = AiActionRoundDecision {
+        call_id: call.id.clone(),
+        kind: AiActionRoundDecisionKind::ExecutionCompleted,
+        feedback: None,
+        error: None,
+    };
+    let result = action_round_result(
+        &call,
+        &decision,
+        AgentActionResultSnapshot {
+            id: call.id.clone(),
+            tool: "execute_terminal_command".to_string(),
+            status: AgentActionStatus::Succeeded,
+            summary: Some("终端命令执行成功".to_string()),
+            error: None,
+            duration_ms: Some(41),
+            command: Some(AgentCommandResultSnapshot {
+                phase: AgentCommandExecutionPhase::Completed,
+                output: Some("active".to_string()),
+                output_truncated: false,
+                stdout: Some("active".to_string()),
+                stdout_truncated: false,
+                stderr: Some(String::new()),
+                stderr_truncated: false,
+                exit_code: Some(0),
+                duration_ms: Some(41),
+                reason: None,
+            }),
+        },
+    )
+    .unwrap();
+    let content: Value = serde_json::from_str(&result.content).unwrap();
+    assert_eq!(content["decision"], "approved_and_completed");
+    assert_eq!(content["exitCode"], 0);
+    assert_eq!(content["output"], "active");
+}
+
+#[test]
+fn action_round_result_preserves_revision_feedback_without_execution_data() {
+    let call = AiToolCall {
+        id: "command-2".to_string(),
+        name: "propose_terminal_command".to_string(),
+        arguments: "{}".to_string(),
+    };
+    let result = action_round_result(
+        &call,
+        &AiActionRoundDecision {
+            call_id: call.id.clone(),
+            kind: AiActionRoundDecisionKind::RevisionRequested,
+            feedback: Some("只检查状态".to_string()),
+            error: None,
+        },
+        AgentActionResultSnapshot {
+            id: call.id.clone(),
+            tool: "execute_terminal_command".to_string(),
+            status: AgentActionStatus::Rejected,
+            summary: Some("用户拒绝了该动作".to_string()),
+            error: None,
+            duration_ms: None,
+            command: None,
+        },
+    )
+    .unwrap();
+    let content: Value = serde_json::from_str(&result.content).unwrap();
+    assert_eq!(content["decision"], "revision_requested");
+    assert_eq!(content["feedback"], "只检查状态");
+}
 
 fn policy_context(mode: &str) -> AgentTaskContext {
     serde_json::from_value(json!({

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -17,13 +17,76 @@ use super::{
     diagnostic_policy_evaluations, diagnostic_tool_requires_connection, enabled_diagnostic_tools,
     filter_tool_definitions, http_messages, invalid_tool_call_round, is_local_endpoint,
     is_tool_unsupported_error, normalize_models, sanitize_context, service_endpoint, stream_delta,
-    stream_tool_call_deltas, tool_allowed, tool_definitions, tool_loop_finalize_reason,
-    tool_probe_supported, valid_stream_probe_event, valid_tool_arguments,
-    validate_diagnostic_plan_calls, validate_enabled_diagnostic_calls, validate_service_url,
-    validate_tool_rounds, AiActionRoundDecision, AiActionRoundDecisionKind, AiCapabilityKind,
-    AiCapabilityState, AiChatMessage, AiFinalizeReason, AiModelEntry, AiToolCall, AiToolResult,
-    AiToolRound, SseParser,
+    stream_tool_call_deltas, supported_tool_names, tool_allowed, tool_definitions,
+    tool_loop_finalize_reason, tool_probe_supported, valid_stream_probe_event,
+    valid_tool_arguments, validate_diagnostic_plan_calls, validate_enabled_diagnostic_calls,
+    validate_service_url, validate_tool_rounds, AiActionRoundDecision, AiActionRoundDecisionKind,
+    AiCapabilityKind, AiCapabilityState, AiChatMessage, AiFinalizeReason, AiModelEntry, AiToolCall,
+    AiToolResult, AiToolRound, SseParser,
 };
+
+#[test]
+fn shared_tool_catalog_matches_provider_schemas_and_argument_validators() {
+    let definitions = tool_definitions(true, true, true);
+    let definition_names = definitions
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|definition| {
+            assert_eq!(definition["type"], "function");
+            assert_eq!(
+                definition["function"]["parameters"]["additionalProperties"],
+                false
+            );
+            definition["function"]["name"].as_str().unwrap()
+        })
+        .collect::<HashSet<_>>();
+    let catalog_names = supported_tool_names().collect::<HashSet<_>>();
+    assert_eq!(definition_names, catalog_names);
+
+    let valid_samples = [
+        ("get_server_status", r#"{}"#),
+        ("list_processes", r#"{}"#),
+        ("get_current_directory", r#"{}"#),
+        ("get_network_connections", r#"{}"#),
+        ("inspect_service", r#"{"service":"nginx.service"}"#),
+        (
+            "read_service_logs",
+            r#"{"service":"nginx.service","lines":20}"#,
+        ),
+        ("ping_target", r#"{"target":"example.com"}"#),
+        ("trace_route", r#"{"target":"example.com"}"#),
+        (
+            "propose_file_edit",
+            r#"{"path":"/srv/app.conf","content":"enabled=true"}"#,
+        ),
+        (
+            "propose_file_operation",
+            r#"{"operation":"delete","path":"/srv/app.conf"}"#,
+        ),
+        (
+            "propose_terminal_command",
+            r#"{"command":"pwd","purpose":"Inspect directory","risk":"safe","risk_reason":"Reads the current directory"}"#,
+        ),
+        (
+            "propose_service_action",
+            r#"{"service":"nginx.service","action":"status"}"#,
+        ),
+    ];
+    assert_eq!(
+        valid_samples
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<HashSet<_>>(),
+        catalog_names
+    );
+    for (name, arguments) in valid_samples {
+        assert!(
+            valid_tool_arguments(name, arguments),
+            "shared tool `{name}` must have a matching argument validator"
+        );
+    }
+}
 
 #[test]
 fn action_round_result_uses_the_authoritative_command_snapshot() {

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -17,12 +17,12 @@ use super::{
     diagnostic_policy_evaluations, diagnostic_tool_requires_connection, enabled_diagnostic_tools,
     filter_tool_definitions, http_messages, invalid_tool_call_round, is_local_endpoint,
     is_tool_unsupported_error, normalize_models, sanitize_context, service_endpoint, stream_delta,
-    stream_tool_call_deltas, supported_tool_names, tool_allowed, tool_definitions,
-    tool_loop_finalize_reason, tool_probe_supported, valid_stream_probe_event,
+    stream_tool_call_deltas, supported_tool_names, take_pre_resolved_tool_round, tool_allowed,
+    tool_definitions, tool_loop_finalize_reason, tool_probe_supported, valid_stream_probe_event,
     valid_tool_arguments, validate_diagnostic_plan_calls, validate_enabled_diagnostic_calls,
     validate_service_url, validate_tool_rounds, AiActionRoundDecision, AiActionRoundDecisionKind,
-    AiCapabilityKind, AiCapabilityState, AiChatMessage, AiFinalizeReason, AiModelEntry, AiToolCall,
-    AiToolResult, AiToolRound, SseParser,
+    AiCapabilityKind, AiCapabilityState, AiChatMessage, AiChatResult, AiFinalizeReason,
+    AiModelEntry, AiRequestTelemetry, AiToolCall, AiToolResult, AiToolRound, SseParser,
 };
 
 #[test]
@@ -86,6 +86,50 @@ fn shared_tool_catalog_matches_provider_schemas_and_argument_validators() {
             "shared tool `{name}` must have a matching argument validator"
         );
     }
+}
+
+#[test]
+fn pre_resolved_tool_results_are_returned_to_the_next_model_round() {
+    let call = AiToolCall {
+        id: "call-unknown".to_string(),
+        name: "unknown_tool".to_string(),
+        arguments: r#"{"value":true}"#.to_string(),
+    };
+    let result = AiToolResult {
+        call_id: call.id.clone(),
+        name: call.name.clone(),
+        content: r#"{"ok":false,"error":"tool_not_enabled"}"#.to_string(),
+    };
+    let mut response = AiChatResult {
+        content: "  I will retry with an enabled tool.  ".to_string(),
+        reasoning_content: Some("Select a supported diagnostic.".to_string()),
+        tool_calls: vec![call.clone()],
+        pre_resolved_tool_results: vec![result.clone()],
+        action_intents: Vec::new(),
+        diagnostic_plans: Vec::new(),
+        diagnostic_tool_rounds: Vec::new(),
+        telemetry: AiRequestTelemetry {
+            duration_ms: 10,
+            request_count: 1,
+            usage: None,
+        },
+    };
+
+    let round = take_pre_resolved_tool_round(&mut response).unwrap();
+    assert_eq!(round.calls.len(), 1);
+    assert_eq!(round.calls[0].id, call.id);
+    assert_eq!(
+        round.content.as_deref(),
+        Some("I will retry with an enabled tool.")
+    );
+    assert_eq!(
+        round.reasoning_content.as_deref(),
+        Some("Select a supported diagnostic.")
+    );
+    assert_eq!(round.results.len(), 1);
+    assert_eq!(round.results[0].call_id, result.call_id);
+    assert!(response.pre_resolved_tool_results.is_empty());
+    assert!(take_pre_resolved_tool_round(&mut response).is_none());
 }
 
 #[test]

--- a/src-tauri/src/ai/tests.rs
+++ b/src-tauri/src/ai/tests.rs
@@ -857,6 +857,41 @@ fn turns_invalid_command_arguments_into_a_retryable_tool_round() {
 }
 
 #[test]
+fn turns_mixed_diagnostic_and_action_calls_into_a_retryable_tool_round() {
+    let calls = vec![
+        AiToolCall {
+            id: "call-status".to_string(),
+            name: "get_server_status".to_string(),
+            arguments: r#"{"reason":"Inspect current usage"}"#.to_string(),
+        },
+        AiToolCall {
+            id: "call-command".to_string(),
+            name: "propose_service_action".to_string(),
+            arguments: r#"{"service":"nginx.service","action":"restart"}"#.to_string(),
+        },
+    ];
+
+    let round = invalid_tool_call_round(&calls, "I will inspect and restart it.", None).unwrap();
+    assert_eq!(round.calls.len(), calls.len());
+    assert_eq!(round.calls[0].id, calls[0].id);
+    assert_eq!(round.calls[1].id, calls[1].id);
+    assert_eq!(round.results.len(), 2);
+    for result in round.results {
+        let value = serde_json::from_str::<Value>(&result.content).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["retryable"], true);
+        assert!(value["error"]
+            .as_str()
+            .unwrap()
+            .contains("不能同时包含诊断工具和操作提案"));
+        assert!(value["instruction"]
+            .as_str()
+            .unwrap()
+            .contains("never both"));
+    }
+}
+
+#[test]
 fn falls_back_only_when_a_provider_rejects_tool_calling() {
     assert!(is_tool_unsupported_error(
         400,

--- a/src-tauri/src/ai/validation.rs
+++ b/src-tauri/src/ai/validation.rs
@@ -300,6 +300,19 @@ pub(super) fn validate_diagnostic_plan_calls(calls: &[AiToolCall]) -> Result<(),
     Ok(())
 }
 
+fn validate_tool_call_composition(calls: &[AiToolCall]) -> Result<(), String> {
+    let has_diagnostic = calls.iter().any(|call| diagnostic_tool(&call.name));
+    let has_action = calls
+        .iter()
+        .any(|call| file_mutation_tool(&call.name) || command_proposal_tool(&call.name));
+    if has_diagnostic && has_action {
+        return Err(
+            "AI 同一响应不能同时包含诊断工具和操作提案，请先完成诊断再提出操作".to_string(),
+        );
+    }
+    Ok(())
+}
+
 pub(super) fn valid_tool_arguments(name: &str, arguments: &str) -> bool {
     let Ok(Value::Object(arguments)) = serde_json::from_str::<Value>(arguments) else {
         return false;
@@ -426,19 +439,28 @@ pub(super) fn invalid_tool_call_round(
         .iter()
         .map(tool_call_argument_error)
         .collect::<Vec<_>>();
-    let plan_error = validate_diagnostic_plan_calls(calls).err();
-    if errors.iter().all(Option::is_none) && plan_error.is_none() {
+    let batch_error = validate_tool_call_composition(calls)
+        .and_then(|_| validate_diagnostic_plan_calls(calls))
+        .err();
+    if errors.iter().all(Option::is_none) && batch_error.is_none() {
         return None;
     }
 
-    let retry_instruction = "Correct the tool arguments and return the complete tool call set again. Do not claim that any rejected call was executed.";
+    let retry_instruction = if batch_error
+        .as_deref()
+        .is_some_and(|error| error.contains("同时包含诊断工具和操作提案"))
+    {
+        "Return either diagnostic calls or action proposals in this response, never both. Complete diagnostics first, consume their results, then propose actions in a later response."
+    } else {
+        "Correct the tool arguments and return the complete tool call set again. Do not claim that any rejected call was executed."
+    };
     let results = calls
         .iter()
         .zip(errors.iter_mut())
         .map(|(call, error)| {
             let error = error
                 .take()
-                .or_else(|| plan_error.clone())
+                .or_else(|| batch_error.clone())
                 .unwrap_or_else(|| "同一响应中包含无效工具调用，因此本调用未执行".to_string());
             AiToolResult {
                 call_id: call.id.clone(),

--- a/src-tauri/src/ai/validation.rs
+++ b/src-tauri/src/ai/validation.rs
@@ -1,5 +1,81 @@
 use super::*;
 
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+enum AiToolKind {
+    Diagnostic,
+    FileMutation,
+    CommandProposal,
+}
+
+#[derive(Debug, Deserialize)]
+struct AiToolCatalogEntry {
+    label: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AiToolCatalogGroups {
+    diagnostic: HashMap<String, AiToolCatalogEntry>,
+    file_mutation: HashMap<String, AiToolCatalogEntry>,
+    command_proposal: HashMap<String, AiToolCatalogEntry>,
+}
+
+static AI_TOOL_CATALOG: LazyLock<HashMap<String, (AiToolKind, String)>> = LazyLock::new(|| {
+    let groups: AiToolCatalogGroups =
+        serde_json::from_str(include_str!("../../../src/ai-tool-catalog.json"))
+            .expect("shared AI tool catalog must be valid");
+    let mut catalog = HashMap::new();
+    for (name, entry) in groups.diagnostic {
+        assert!(
+            catalog
+                .insert(name, (AiToolKind::Diagnostic, entry.label))
+                .is_none(),
+            "shared AI tool names must be unique"
+        );
+    }
+    for (name, entry) in groups.file_mutation {
+        assert!(
+            catalog
+                .insert(name, (AiToolKind::FileMutation, entry.label))
+                .is_none(),
+            "shared AI tool names must be unique"
+        );
+    }
+    for (name, entry) in groups.command_proposal {
+        assert!(
+            catalog
+                .insert(name, (AiToolKind::CommandProposal, entry.label))
+                .is_none(),
+            "shared AI tool names must be unique"
+        );
+    }
+    catalog
+});
+
+fn tool_kind(name: &str) -> Option<AiToolKind> {
+    AI_TOOL_CATALOG.get(name).map(|(kind, _)| *kind)
+}
+
+pub(super) fn tool_label(name: &str) -> Option<&'static str> {
+    AI_TOOL_CATALOG.get(name).map(|(_, label)| label.as_str())
+}
+
+pub(super) fn diagnostic_tool_names() -> impl Iterator<Item = &'static str> {
+    AI_TOOL_CATALOG
+        .iter()
+        .filter_map(|(name, (kind, _))| (*kind == AiToolKind::Diagnostic).then_some(name.as_str()))
+}
+
+#[cfg(test)]
+pub(super) fn supported_tool_names() -> impl Iterator<Item = &'static str> {
+    AI_TOOL_CATALOG.keys().map(String::as_str)
+}
+
+#[cfg(test)]
+pub(super) fn supported_tool(name: &str) -> bool {
+    tool_kind(name).is_some()
+}
+
 pub(super) fn private_key_regex() -> Regex {
     Regex::new(r"(?is)-----BEGIN [^-]*PRIVATE KEY-----.*?-----END [^-]*PRIVATE KEY-----")
         .expect("private key regex must be valid")
@@ -58,34 +134,16 @@ pub(super) fn validate_messages(
     Ok(messages)
 }
 
-pub(super) fn supported_tool(name: &str) -> bool {
-    matches!(
-        name,
-        "get_server_status"
-            | "list_processes"
-            | "get_current_directory"
-            | "get_network_connections"
-            | "inspect_service"
-            | "read_service_logs"
-            | "ping_target"
-            | "trace_route"
-            | "propose_terminal_command"
-            | "propose_service_action"
-            | "propose_file_edit"
-            | "propose_file_operation"
-    )
-}
-
 pub(super) fn file_mutation_tool(name: &str) -> bool {
-    matches!(name, "propose_file_edit" | "propose_file_operation")
+    tool_kind(name) == Some(AiToolKind::FileMutation)
 }
 
 pub(super) fn command_proposal_tool(name: &str) -> bool {
-    matches!(name, "propose_terminal_command" | "propose_service_action")
+    tool_kind(name) == Some(AiToolKind::CommandProposal)
 }
 
 pub(super) fn diagnostic_tool(name: &str) -> bool {
-    !file_mutation_tool(name) && !command_proposal_tool(name) && supported_tool(name)
+    tool_kind(name) == Some(AiToolKind::Diagnostic)
 }
 
 pub(super) fn enabled_diagnostic_tools(
@@ -93,21 +151,9 @@ pub(super) fn enabled_diagnostic_tools(
     legacy_enabled: bool,
 ) -> Result<HashSet<String>, String> {
     if values.is_empty() && legacy_enabled {
-        return Ok([
-            "get_server_status",
-            "list_processes",
-            "get_current_directory",
-            "get_network_connections",
-            "inspect_service",
-            "read_service_logs",
-            "ping_target",
-            "trace_route",
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect());
+        return Ok(diagnostic_tool_names().map(str::to_string).collect());
     }
-    if values.len() > 8 {
+    if values.len() > diagnostic_tool_names().count() {
         return Err("AI 只读工具权限数量无效".to_string());
     }
     let mut enabled = HashSet::new();

--- a/src-tauri/src/ai_rig.rs
+++ b/src-tauri/src/ai_rig.rs
@@ -369,6 +369,34 @@ fn extract_reasoning_content(choice: &OneOrMany<AssistantContent>) -> Option<Str
     (!parts.is_empty()).then(|| parts.join("\n"))
 }
 
+fn has_native_tool_calls(choice: &OneOrMany<AssistantContent>) -> bool {
+    choice
+        .iter()
+        .any(|item| matches!(item, AssistantContent::ToolCall(_)))
+}
+
+fn resolve_tool_protocol(
+    content: &str,
+    choice: &OneOrMany<AssistantContent>,
+    request_id: &str,
+    round_index: usize,
+) -> Result<(String, Option<ParsedDsmlResponse>), RigTurnError> {
+    if has_native_tool_calls(choice) {
+        let visible = DSML_TOOL_CALLS_START
+            .find(content)
+            .map_or(content, |marker| &content[..marker.start()])
+            .trim_end()
+            .to_string();
+        return Ok((visible, None));
+    }
+
+    let parsed = parse_dsml_response(content, request_id, round_index)?;
+    let visible = parsed
+        .as_ref()
+        .map_or_else(|| content.to_string(), |parsed| parsed.content.clone());
+    Ok((visible, parsed))
+}
+
 struct PreparedTurn {
     run: AgentRun,
     prompt: Message,
@@ -675,9 +703,14 @@ async fn stream_model_turn<M: CompletionModel>(
             StreamKind::Reasoning,
         );
     }
-    let parsed_dsml = parse_dsml_response(&content, context.request_id, context.round_index)?;
+    let (resolved_content, parsed_dsml) = resolve_tool_protocol(
+        &content,
+        &original_choice,
+        context.request_id,
+        context.round_index,
+    )?;
+    content = resolved_content;
     let choice = if let Some(parsed) = parsed_dsml {
-        content = parsed.content;
         let mut response = Vec::new();
         if let Some(reasoning) = reasoning_content.as_deref() {
             response.push(AssistantContent::reasoning(reasoning));
@@ -841,8 +874,8 @@ mod tests {
 
     use super::{
         extract_reasoning_content, invalid_tool_retry_feedback, parse_dsml_response, prepare_turn,
-        reasoning_stream_delta, retry_invalid_tool_call, tool_definitions, DsmlStreamFilter,
-        StreamKind, StreamPayload,
+        reasoning_stream_delta, resolve_tool_protocol, retry_invalid_tool_call, tool_definitions,
+        DsmlStreamFilter, StreamKind, StreamPayload,
     };
     use crate::ai::{AiChatMessage, AiToolCall, AiToolResult, AiToolRound};
 
@@ -968,6 +1001,44 @@ mod tests {
         );
         assert_eq!(arguments["purpose"], "搜索 Nginx 配置文件");
         assert_eq!(arguments["metadata"]["source"], "agent");
+    }
+
+    #[test]
+    fn native_tool_calls_take_precedence_over_dsml_fallback_markup() {
+        let choice = OneOrMany::many(vec![
+            AssistantContent::text("Use the native call."),
+            AssistantContent::ToolCall(ToolCall::new(
+                "native-call".to_string(),
+                ToolFunction::new("get_server_status".to_string(), json!({})),
+            )),
+        ])
+        .unwrap();
+        let content = r#"Use the native call.
+<|DSML|tool_calls><|DSML|invoke name="get_server_status"><|DSML|parameter name="reason" string="true">duplicate</|DSML|parameter></|DSML|invoke></|DSML|tool_calls>"#;
+
+        let (visible, fallback) =
+            resolve_tool_protocol(content, &choice, "request-native", 0).unwrap();
+
+        assert_eq!(visible, "Use the native call.");
+        assert!(fallback.is_none());
+        assert!(choice
+            .iter()
+            .any(|item| matches!(item, AssistantContent::ToolCall(_))));
+    }
+
+    #[test]
+    fn dsml_is_used_only_when_native_tool_calls_are_absent() {
+        let choice = OneOrMany::one(AssistantContent::text("compatibility response"));
+        let content = r#"Checking.
+<|DSML|tool_calls><|DSML|invoke name="get_server_status"><|DSML|parameter name="reason" string="true">inspect</|DSML|parameter></|DSML|invoke></|DSML|tool_calls>"#;
+
+        let (visible, fallback) =
+            resolve_tool_protocol(content, &choice, "request-fallback", 0).unwrap();
+
+        assert_eq!(visible, "Checking.");
+        let fallback = fallback.expect("DSML fallback must be parsed without native calls");
+        assert_eq!(fallback.calls.len(), 1);
+        assert_eq!(fallback.calls[0].name, "get_server_status");
     }
 
     #[test]

--- a/src-tauri/src/ai_rig.rs
+++ b/src-tauri/src/ai_rig.rs
@@ -26,13 +26,12 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::watch;
 
 use crate::{
-    ai::{AiChatMessage, AiToolCall, AiToolRound},
+    ai::{AiChatMessage, AiToolCall, AiToolResult, AiToolRound},
     protocol::AI_STREAM_EVENT,
 };
 
 const MAX_DSML_TOOL_CALLS: usize = 8;
 const MAX_DSML_ARGUMENT_CHARS: usize = 400_000;
-const MAX_INVALID_TOOL_CALL_RETRIES: usize = 1;
 const DSML_TOOL_CALLS_OPEN: &str = "<|DSML|tool_calls>";
 const DSML_TOOL_CALLS_CLOSE: &str = "</|DSML|tool_calls>";
 const DSML_INVOKE_CLOSE: &str = "</|DSML|invoke>";
@@ -297,6 +296,7 @@ pub(crate) struct RigTurnResult {
     pub content: String,
     pub reasoning_content: Option<String>,
     pub tool_calls: Vec<AiToolCall>,
+    pub pre_resolved_tool_results: Vec<AiToolResult>,
     pub request_count: u32,
     pub usage: Option<RigTokenUsage>,
 }
@@ -426,12 +426,7 @@ fn prepare_turn(
     // history instead of imposing a global turn limit on the task.
     let mut run = AgentRun::new(prompt)
         .with_history(messages)
-        .max_turns(
-            rounds
-                .len()
-                .saturating_add(1 + MAX_INVALID_TOOL_CALL_RETRIES),
-        )
-        .max_invalid_tool_call_retries(MAX_INVALID_TOOL_CALL_RETRIES);
+        .max_turns(rounds.len().saturating_add(1));
 
     for round in rounds {
         match run
@@ -568,15 +563,26 @@ struct ModelTurnStreamContext<'a> {
     round_index: usize,
 }
 
-fn invalid_tool_retry_feedback(context: &InvalidToolCallContext) -> String {
+fn invalid_tool_result(context: &InvalidToolCallContext) -> String {
     if context.allowed_tools.is_empty() {
-        return "No tools are available for this turn. Do not emit function calls or DSML tool markup. Reply with a plain-text final answer using only the evidence already available."
-            .to_string();
+        return serde_json::json!({
+            "ok": false,
+            "error": "No tools are available for this turn",
+            "retryable": true,
+            "instruction": "Do not emit function calls or DSML tool markup. Reply with a plain-text final answer using only the evidence already available."
+        })
+        .to_string();
     }
-    format!(
-        "Your previous tool call is unavailable. You may call only these tools: {}. Retry this turn using an allowed tool, or answer without tools. Do not invent or rename tools.",
-        context.allowed_tools.join(", ")
-    )
+    serde_json::json!({
+        "ok": false,
+        "error": format!("Tool `{}` is unavailable for this turn", invalid_tool_display_name(&context.tool_name)),
+        "retryable": true,
+        "instruction": format!(
+            "You may call only these tools: {}. Retry using an allowed tool, or answer without tools. Do not invent or rename tools.",
+            context.allowed_tools.join(", ")
+        )
+    })
+    .to_string()
 }
 
 fn invalid_tool_display_name(name: &str) -> String {
@@ -592,22 +598,14 @@ fn invalid_tool_display_name(name: &str) -> String {
     }
 }
 
-fn retry_invalid_tool_call(
+fn skip_invalid_tool_call(
     run: &mut AgentRun,
     context: &InvalidToolCallContext,
-) -> Result<(), RigTurnError> {
-    let invalid_name = invalid_tool_display_name(&context.tool_name);
-    match run.resolve_invalid_tool_call(InvalidToolCallHookAction::retry(
-        invalid_tool_retry_feedback(context),
-    )) {
-        Ok(ModelTurnOutcome::TurnRetried) => Ok(()),
-        Ok(_) => Err(RigTurnError::protocol(
-            "AI Agent 未正确恢复不可用的工具调用",
-        )),
-        Err(_) => Err(RigTurnError::protocol(format!(
-            "AI 连续调用不可用工具：{invalid_name}",
-        ))),
-    }
+) -> Result<ModelTurnOutcome, RigTurnError> {
+    run.resolve_invalid_tool_call(InvalidToolCallHookAction::skip(invalid_tool_result(
+        context,
+    )))
+    .map_err(|error| RigTurnError::protocol(error.to_string()))
 }
 
 async fn stream_model_turn<M: CompletionModel>(
@@ -753,8 +751,8 @@ pub(crate) async fn request_turn(
     let names = tool_names(&request.tools);
     let PreparedTurn {
         mut run,
-        mut prompt,
-        mut history,
+        prompt,
+        history,
     } = prepare_turn(request.messages, request.tool_rounds, &names)?;
     let rig_client = openai::CompletionsClient::builder()
         .api_key(request.api_key.unwrap_or("fineshell-local"))
@@ -773,77 +771,82 @@ pub(crate) async fn request_turn(
     };
     let mut aggregate_usage = Usage::new();
     let mut request_count = 0_u32;
-    let (mut content, reasoning_content) = loop {
-        let streamed = stream_model_turn(
-            &model,
-            prompt,
-            history,
-            &stream_context,
-            request.cancellation,
-        )
-        .await?;
-        let StreamedModelTurn {
-            choice,
-            content,
+    let streamed = stream_model_turn(
+        &model,
+        prompt,
+        history,
+        &stream_context,
+        request.cancellation,
+    )
+    .await?;
+    let StreamedModelTurn {
+        choice,
+        mut content,
+        message_id,
+        reasoning_content,
+        usage,
+    } = streamed;
+    request_count = request_count.saturating_add(1);
+    aggregate_usage += usage;
+    let mut outcome = run
+        .model_response(ModelTurn::new(
             message_id,
-            reasoning_content,
+            choice,
             usage,
-        } = streamed;
-        request_count = request_count.saturating_add(1);
-        aggregate_usage += usage;
-        match run
-            .model_response(ModelTurn::new(
-                message_id,
-                choice,
-                usage,
-                names.clone(),
-                names.clone(),
-            ))
-            .map_err(|error| RigTurnError::protocol(error.to_string()))?
-        {
-            ModelTurnOutcome::Continue { .. } => break (content, reasoning_content),
+            names.clone(),
+            names.clone(),
+        ))
+        .map_err(|error| RigTurnError::protocol(error.to_string()))?;
+    loop {
+        match outcome {
+            ModelTurnOutcome::Continue { .. } => break,
             ModelTurnOutcome::NeedsResolution(context) => {
-                retry_invalid_tool_call(&mut run, &context)?;
-                match run
-                    .next_step()
-                    .map_err(|error| RigTurnError::protocol(error.to_string()))?
-                {
-                    AgentRunStep::CallModel {
-                        prompt: next_prompt,
-                        history: next_history,
-                        ..
-                    } => {
-                        prompt = next_prompt;
-                        history = next_history;
-                    }
-                    _ => {
-                        return Err(RigTurnError::protocol("AI Agent 未进入工具调用纠正回合"));
-                    }
-                }
+                outcome = skip_invalid_tool_call(&mut run, &context)?;
             }
             ModelTurnOutcome::TurnRetried => {
                 return Err(RigTurnError::protocol("AI 工具调用状态无效"));
             }
         }
-    };
-    let tool_calls = match run
+    }
+    let (tool_calls, pre_resolved_tool_results) = match run
         .next_step()
         .map_err(|error| RigTurnError::protocol(error.to_string()))?
     {
-        AgentRunStep::CallTools { calls } => calls
-            .into_iter()
-            .enumerate()
-            .map(|(call_index, call)| AiToolCall {
-                id: agent_tool_call_id(request.request_id, round_index, call_index),
-                name: call.tool_call.function.name,
-                arguments: call.tool_call.function.arguments.to_string(),
-            })
-            .collect(),
+        AgentRunStep::CallTools { calls } => {
+            let mut tool_calls = Vec::with_capacity(calls.len());
+            let mut pre_resolved_tool_results = Vec::new();
+            for (call_index, call) in calls.into_iter().enumerate() {
+                let id = agent_tool_call_id(request.request_id, round_index, call_index);
+                let name = call.tool_call.function.name;
+                if let Some(UserContent::ToolResult(result)) = call.preresolved_result {
+                    let content = result
+                        .content
+                        .into_iter()
+                        .filter_map(|content| match content {
+                            ToolResultContent::Text(text) => Some(text.text),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    pre_resolved_tool_results.push(AiToolResult {
+                        call_id: id.clone(),
+                        name: name.clone(),
+                        content,
+                    });
+                }
+                tool_calls.push(AiToolCall {
+                    id,
+                    name,
+                    arguments: call.tool_call.function.arguments.to_string(),
+                });
+            }
+            (tool_calls, pre_resolved_tool_results)
+        }
         AgentRunStep::Done(response) => {
             if content.is_empty() {
                 content = response.output;
             }
-            Vec::new()
+            (Vec::new(), Vec::new())
         }
         AgentRunStep::CallModel { .. } => {
             return Err(RigTurnError::protocol("AI Agent 意外请求了额外模型回合"));
@@ -853,6 +856,7 @@ pub(crate) async fn request_turn(
         content,
         reasoning_content,
         tool_calls,
+        pre_resolved_tool_results,
         request_count,
         usage: aggregate_usage
             .has_values()
@@ -873,8 +877,8 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        extract_reasoning_content, invalid_tool_retry_feedback, parse_dsml_response, prepare_turn,
-        reasoning_stream_delta, resolve_tool_protocol, retry_invalid_tool_call, tool_definitions,
+        extract_reasoning_content, invalid_tool_result, parse_dsml_response, prepare_turn,
+        reasoning_stream_delta, resolve_tool_protocol, skip_invalid_tool_call, tool_definitions,
         DsmlStreamFilter, StreamKind, StreamPayload,
     };
     use crate::ai::{AiChatMessage, AiToolCall, AiToolResult, AiToolRound};
@@ -927,10 +931,8 @@ mod tests {
     }
 
     #[test]
-    fn retries_one_unknown_tool_without_executing_it() {
-        let mut run = AgentRun::new("inspect")
-            .max_turns(2)
-            .max_invalid_tool_call_retries(1);
+    fn turns_one_unknown_tool_into_a_pre_resolved_result() {
+        let mut run = AgentRun::new("inspect").max_turns(2);
         expect_model_turn(&mut run);
         let context = unknown_tool_context(
             &mut run,
@@ -938,39 +940,31 @@ mod tests {
             BTreeSet::from(["get_server_status".to_string()]),
         );
 
-        assert!(invalid_tool_retry_feedback(&context).contains("get_server_status"));
-        retry_invalid_tool_call(&mut run, &context).unwrap();
-        expect_model_turn(&mut run);
+        assert!(invalid_tool_result(&context).contains("get_server_status"));
+        assert!(matches!(
+            skip_invalid_tool_call(&mut run, &context).unwrap(),
+            ModelTurnOutcome::Continue { .. }
+        ));
+        let AgentRunStep::CallTools { calls } = run.next_step().unwrap() else {
+            panic!("skipped tool must produce a tool-result round");
+        };
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].preresolved_result.is_some());
     }
 
     #[test]
-    fn asks_for_plain_text_when_no_tools_are_available() {
-        let mut run = AgentRun::new("summarize")
-            .max_turns(2)
-            .max_invalid_tool_call_retries(1);
+    fn asks_for_plain_text_through_a_tool_result_when_no_tools_are_available() {
+        let mut run = AgentRun::new("summarize").max_turns(2);
         expect_model_turn(&mut run);
         let context = unknown_tool_context(&mut run, "stale_tool", BTreeSet::new());
 
-        let feedback = invalid_tool_retry_feedback(&context);
+        let feedback = invalid_tool_result(&context);
         assert!(feedback.contains("No tools are available"));
         assert!(feedback.contains("plain-text final answer"));
-        retry_invalid_tool_call(&mut run, &context).unwrap();
-        expect_model_turn(&mut run);
-    }
-
-    #[test]
-    fn reports_a_clear_error_after_the_unknown_tool_retry_is_exhausted() {
-        let mut run = AgentRun::new("inspect")
-            .max_turns(2)
-            .max_invalid_tool_call_retries(1);
-        expect_model_turn(&mut run);
-        let first = unknown_tool_context(&mut run, "first_unknown", BTreeSet::new());
-        retry_invalid_tool_call(&mut run, &first).unwrap();
-        expect_model_turn(&mut run);
-        let repeated = unknown_tool_context(&mut run, "second_unknown", BTreeSet::new());
-
-        let error = retry_invalid_tool_call(&mut run, &repeated).unwrap_err();
-        assert_eq!(error.message, "AI 连续调用不可用工具：second_unknown");
+        assert!(matches!(
+            skip_invalid_tool_call(&mut run, &context).unwrap(),
+            ModelTurnOutcome::Continue { .. }
+        ));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             ai::ai_task_action_results,
             agent::ai_task_get,
             agent::ai_task_events_since,
+            agent::ai_task_sync,
             agent::ai_task_recovery_decide,
             agent::ai_task_plan_decide,
             agent::ai_task_action_transition,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub fn run() {
             ai::ai_probe_capabilities,
             ai::ai_chat_start,
             ai::ai_chat_cancel,
+            ai::ai_task_action_results,
             agent::ai_task_get,
             agent::ai_task_events_since,
             agent::ai_task_recovery_decide,

--- a/src-tauri/src/protocol.rs
+++ b/src-tauri/src/protocol.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-pub(crate) const PROTOCOL_VERSION: u16 = 33;
+pub(crate) const PROTOCOL_VERSION: u16 = 34;
 
 pub(crate) const SSH_OUTPUT_EVENT: &str = "ssh-output";
 pub(crate) const SSH_STATUS_EVENT: &str = "ssh-status";

--- a/src-tauri/src/protocol.rs
+++ b/src-tauri/src/protocol.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-pub(crate) const PROTOCOL_VERSION: u16 = 32;
+pub(crate) const PROTOCOL_VERSION: u16 = 33;
 
 pub(crate) const SSH_OUTPUT_EVENT: &str = "ssh-output";
 pub(crate) const SSH_STATUS_EVENT: &str = "ssh-status";

--- a/src/ai-permissions.test.ts
+++ b/src/ai-permissions.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import {
+  AI_READ_ONLY_TOOL_OPTIONS,
   ALL_AI_READ_ONLY_TOOLS,
+  aiReadOnlyToolLabel,
   aiReadOnlyToolEnabled,
   sanitizeAiReadOnlyTools,
 } from "./ai-permissions";
 
 describe("AI permission settings", () => {
+  test("derives names and labels from the shared tool catalog", () => {
+    expect(AI_READ_ONLY_TOOL_OPTIONS).toHaveLength(8);
+    expect(aiReadOnlyToolLabel("inspect_service")).toBe("检查服务状态");
+    expect(AI_READ_ONLY_TOOL_OPTIONS.map(({ value }) => value)).toEqual(
+      ALL_AI_READ_ONLY_TOOLS,
+    );
+  });
+
   test("migrates the legacy master switch without broadening access", () => {
     expect(sanitizeAiReadOnlyTools(undefined, false)).toEqual([]);
     expect(sanitizeAiReadOnlyTools(undefined, true)).toEqual(

--- a/src/ai-permissions.ts
+++ b/src/ai-permissions.ts
@@ -1,22 +1,23 @@
-export const AI_READ_ONLY_TOOL_OPTIONS = [
-  { label: "服务器状态", value: "get_server_status" },
-  { label: "进程列表", value: "list_processes" },
-  { label: "当前目录", value: "get_current_directory" },
-  { label: "网络连接", value: "get_network_connections" },
-  { label: "服务状态", value: "inspect_service" },
-  { label: "服务日志", value: "read_service_logs" },
-  { label: "Ping", value: "ping_target" },
-  { label: "路由追踪", value: "trace_route" },
-] as const;
+import toolCatalog from "./ai-tool-catalog.json";
 
-export type AiReadOnlyToolName =
-  (typeof AI_READ_ONLY_TOOL_OPTIONS)[number]["value"];
+export type AiReadOnlyToolName = keyof typeof toolCatalog.diagnostic;
+
+export const AI_READ_ONLY_TOOL_OPTIONS = Object.entries(
+  toolCatalog.diagnostic,
+).map(([value, definition]) => ({
+  label: definition.label,
+  value: value as AiReadOnlyToolName,
+}));
 
 export const ALL_AI_READ_ONLY_TOOLS = AI_READ_ONLY_TOOL_OPTIONS.map(
   ({ value }) => value,
 );
 
 const AI_READ_ONLY_TOOL_SET = new Set<string>(ALL_AI_READ_ONLY_TOOLS);
+
+export function aiReadOnlyToolLabel(name: AiReadOnlyToolName) {
+  return toolCatalog.diagnostic[name].label;
+}
 
 export function isAiReadOnlyToolName(
   value: string,

--- a/src/ai-tool-catalog.json
+++ b/src/ai-tool-catalog.json
@@ -1,0 +1,20 @@
+{
+  "diagnostic": {
+    "get_server_status": { "label": "读取服务器状态" },
+    "list_processes": { "label": "读取进程列表" },
+    "get_current_directory": { "label": "读取当前目录" },
+    "get_network_connections": { "label": "读取网络连接" },
+    "inspect_service": { "label": "检查服务状态" },
+    "read_service_logs": { "label": "读取服务日志" },
+    "ping_target": { "label": "Ping" },
+    "trace_route": { "label": "路由追踪" }
+  },
+  "fileMutation": {
+    "propose_file_edit": { "label": "文件修改提案" },
+    "propose_file_operation": { "label": "文件操作提案" }
+  },
+  "commandProposal": {
+    "propose_terminal_command": { "label": "终端命令提案" },
+    "propose_service_action": { "label": "服务操作提案" }
+  }
+}

--- a/src/ai-tools.ts
+++ b/src/ai-tools.ts
@@ -11,6 +11,7 @@ import type {
 } from "./tauri-protocol";
 import { redactAiContext } from "./ai-utils";
 import {
+  aiReadOnlyToolLabel,
   isAiReadOnlyToolName,
   type AiReadOnlyToolName,
 } from "./ai-permissions";
@@ -42,17 +43,6 @@ export interface AiToolRun {
   startedAt: number;
   status: AiToolRunStatus;
 }
-
-const TOOL_LABELS: Record<AiReadOnlyToolName, string> = {
-  get_server_status: "读取服务器状态",
-  list_processes: "读取进程列表",
-  get_current_directory: "读取当前目录",
-  get_network_connections: "读取网络连接",
-  inspect_service: "检查服务状态",
-  read_service_logs: "读取服务日志",
-  ping_target: "Ping",
-  trace_route: "路由追踪",
-};
 
 const TARGET_TOOLS = new Set<AiReadOnlyToolName>([
   "ping_target",
@@ -112,7 +102,9 @@ export function aiToolTarget(call: AiToolCall): string | undefined {
 }
 
 export function aiToolLabel(name: string) {
-  return isAiReadOnlyToolName(name) ? TOOL_LABELS[name] : "未知只读工具";
+  return isAiReadOnlyToolName(name)
+    ? aiReadOnlyToolLabel(name)
+    : "未知只读工具";
 }
 
 export function finishAiToolRun(
@@ -282,7 +274,7 @@ export function sanitizePersistedAiToolRuns(value: unknown): AiToolRun[] | undef
             ? undefined
             : Math.min(60_000, Math.max(0, Math.round(duration))),
         error: boundedSafeText(item.error, 300),
-        label: TOOL_LABELS[name],
+        label: aiReadOnlyToolLabel(name),
         name,
         optional: item.optional === true || undefined,
         planId,

--- a/src/components/HostManagerPanel.tsx
+++ b/src/components/HostManagerPanel.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { CSSProperties } from "react";
 import {
   Button,
   Empty,
@@ -146,6 +153,7 @@ interface HostManagerPanelProps {
 }
 
 function HostManagerPanel({ onConnect, settings }: HostManagerPanelProps) {
+  const hostTableContainerRef = useRef<HTMLDivElement>(null);
   const [hosts, setHosts] = useState<HostRecord[]>([]);
   const [history, setHistory] = useState<ConnectionHistoryRecord[]>([]);
   const [proxies, setProxies] = useState<ProxyRecord[]>([]);
@@ -157,6 +165,31 @@ function HostManagerPanel({ onConnect, settings }: HostManagerPanelProps) {
   const [editorVisible, setEditorVisible] = useState(false);
   const [editingHost, setEditingHost] = useState<HostRecord | null>(null);
   const [historyVisible, setHistoryVisible] = useState(false);
+  const [hostTableBodyHeight, setHostTableBodyHeight] = useState(1);
+
+  useLayoutEffect(() => {
+    const container = hostTableContainerRef.current;
+    if (!container) return;
+
+    const updateTableBodyHeight = () => {
+      const header =
+        container.querySelector<HTMLElement>(".arco-table-header") ??
+        container.querySelector<HTMLElement>("thead");
+      const headerHeight = header?.getBoundingClientRect().height ?? 0;
+      const nextHeight = Math.max(
+        1,
+        Math.floor(container.getBoundingClientRect().height - headerHeight),
+      );
+      setHostTableBodyHeight((currentHeight) =>
+        currentHeight === nextHeight ? currentHeight : nextHeight,
+      );
+    };
+
+    updateTableBodyHeight();
+    const resizeObserver = new ResizeObserver(updateTableBodyHeight);
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, []);
 
   useEffect(() => {
     let disposed = false;
@@ -808,7 +841,15 @@ function HostManagerPanel({ onConnect, settings }: HostManagerPanelProps) {
             </Tooltip>
           </div>
         </div>
-        <div className="host-tree-table-container">
+        <div
+          className="host-tree-table-container"
+          ref={hostTableContainerRef}
+          style={
+            {
+              "--host-table-body-height": `${hostTableBodyHeight}px`,
+            } as CSSProperties
+          }
+        >
           <Table
             border={false}
             className="host-tree-table"
@@ -843,6 +884,7 @@ function HostManagerPanel({ onConnect, settings }: HostManagerPanelProps) {
                 : "host-table-host-row"
             }
             rowKey="id"
+            scroll={{ y: hostTableBodyHeight }}
             size="small"
           />
         </div>

--- a/src/components/SettingsWindow.test.tsx
+++ b/src/components/SettingsWindow.test.tsx
@@ -77,7 +77,9 @@ describe("SettingsWindow", () => {
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(false);
-    expect(screen.getByRole("checkbox", { name: "服务器状态" })).not.toBeNull();
+    expect(
+      screen.getByRole("checkbox", { name: "读取服务器状态" }),
+    ).not.toBeNull();
     expect(screen.getByRole("checkbox", { name: "路由追踪" })).not.toBeNull();
     expect(screen.getByLabelText("允许 AI 生成文件变更提案")).not.toBeNull();
     expect(screen.getByLabelText("允许 AI 生成终端命令提案")).not.toBeNull();

--- a/src/hooks/agent-task-event-state.test.ts
+++ b/src/hooks/agent-task-event-state.test.ts
@@ -40,6 +40,30 @@ describe("agent task event state", () => {
         task: task("task-1", 6),
       }),
     ).toBe(next);
+    expect(
+      applyAgentTaskEvent(next, "task-1", {
+        kind: "plan_updated",
+        protocolVersion: PROTOCOL_VERSION,
+        sequence: 6,
+        task: task("task-2", 6),
+      }),
+    ).toBe(next);
+    expect(
+      applyAgentTaskEvent(next, "task-1", {
+        kind: "plan_updated",
+        protocolVersion: PROTOCOL_VERSION,
+        sequence: 7,
+        task: task("task-1", 6),
+      }),
+    ).toBe(next);
+    expect(
+      applyAgentTaskEvent(next, undefined, {
+        kind: "plan_updated",
+        protocolVersion: PROTOCOL_VERSION,
+        sequence: 6,
+        task: task("task-1", 6),
+      }),
+    ).toBe(next);
   });
 
   test("reconciles a snapshot with later events", () => {
@@ -56,5 +80,57 @@ describe("agent task event state", () => {
         }],
       }),
     ).toBe(replayed);
+  });
+
+  test("keeps the newest task across stale snapshots and unordered replay", () => {
+    const current = task("task-1", 8);
+    const newest = task("task-1", 10);
+    expect(
+      reconcileAgentTaskSync(current, "task-1", {
+        task: task("task-1", 3),
+        events: [
+          {
+            kind: "task_completed",
+            protocolVersion: PROTOCOL_VERSION,
+            sequence: 10,
+            task: newest,
+          },
+          {
+            kind: "plan_updated",
+            protocolVersion: PROTOCOL_VERSION,
+            sequence: 9,
+            task: task("task-1", 9),
+          },
+          {
+            kind: "task_completed",
+            protocolVersion: PROTOCOL_VERSION,
+            sequence: 11,
+            task: task("task-2", 11),
+          },
+          {
+            kind: "task_completed",
+            protocolVersion: PROTOCOL_VERSION + 1,
+            sequence: 12,
+            task: task("task-1", 12),
+          },
+        ],
+      }),
+    ).toBe(newest);
+  });
+
+  test("drops unrelated local state before applying the tracked snapshot", () => {
+    const snapshot = task("task-1", 2);
+    expect(
+      reconcileAgentTaskSync(task("task-2", 20), "task-1", {
+        task: snapshot,
+        events: [],
+      }),
+    ).toBe(snapshot);
+    expect(
+      reconcileAgentTaskSync(task("task-2", 20), "task-1", {
+        task: task("task-2", 21),
+        events: [],
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/hooks/agent-task-event-state.test.ts
+++ b/src/hooks/agent-task-event-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { PROTOCOL_VERSION, type AgentTask } from "../tauri-protocol";
+import {
+  applyAgentTaskEvent,
+  reconcileAgentTaskSync,
+} from "./agent-task-event-state";
+
+function task(id: string, sequence: number): AgentTask {
+  return {
+    id,
+    lastEventSequence: sequence,
+  } as AgentTask;
+}
+
+describe("agent task event state", () => {
+  test("accepts only matching monotonic protocol events", () => {
+    const current = task("task-1", 4);
+    const next = task("task-1", 5);
+    expect(
+      applyAgentTaskEvent(current, "task-1", {
+        kind: "plan_updated",
+        protocolVersion: PROTOCOL_VERSION,
+        sequence: 5,
+        task: next,
+      }),
+    ).toBe(next);
+    expect(
+      applyAgentTaskEvent(next, "task-1", {
+        kind: "plan_updated",
+        protocolVersion: PROTOCOL_VERSION,
+        sequence: 4,
+        task: current,
+      }),
+    ).toBe(next);
+    expect(
+      applyAgentTaskEvent(next, "task-1", {
+        kind: "plan_updated",
+        protocolVersion: PROTOCOL_VERSION + 1,
+        sequence: 6,
+        task: task("task-1", 6),
+      }),
+    ).toBe(next);
+  });
+
+  test("reconciles a snapshot with later events", () => {
+    const snapshot = task("task-1", 3);
+    const replayed = task("task-1", 5);
+    expect(
+      reconcileAgentTaskSync(undefined, "task-1", {
+        task: snapshot,
+        events: [{
+          kind: "task_completed",
+          protocolVersion: PROTOCOL_VERSION,
+          sequence: 5,
+          task: replayed,
+        }],
+      }),
+    ).toBe(replayed);
+  });
+});

--- a/src/hooks/agent-task-event-state.ts
+++ b/src/hooks/agent-task-event-state.ts
@@ -1,0 +1,50 @@
+import {
+  PROTOCOL_VERSION,
+  type AgentTask,
+  type AgentTaskEventPayload,
+  type AgentTaskSync,
+} from "../tauri-protocol";
+
+function newerTask(
+  current: AgentTask | undefined,
+  candidate: AgentTask,
+): AgentTask {
+  if (
+    current?.id === candidate.id &&
+    current.lastEventSequence >= candidate.lastEventSequence
+  ) {
+    return current;
+  }
+  return candidate;
+}
+
+export function applyAgentTaskEvent(
+  current: AgentTask | undefined,
+  trackedTaskId: string | undefined,
+  event: AgentTaskEventPayload,
+): AgentTask | undefined {
+  if (
+    !trackedTaskId ||
+    event.protocolVersion !== PROTOCOL_VERSION ||
+    event.task.id !== trackedTaskId ||
+    event.sequence !== event.task.lastEventSequence
+  ) {
+    return current;
+  }
+  return newerTask(current, event.task);
+}
+
+export function reconcileAgentTaskSync(
+  current: AgentTask | undefined,
+  trackedTaskId: string,
+  sync: AgentTaskSync,
+): AgentTask | undefined {
+  let next = current?.id === trackedTaskId ? current : undefined;
+  if (sync.task?.id === trackedTaskId) {
+    next = newerTask(next, sync.task);
+  }
+  for (const event of sync.events) {
+    next = applyAgentTaskEvent(next, trackedTaskId, event);
+  }
+  return next;
+}

--- a/src/hooks/ai-proposal-round.test.ts
+++ b/src/hooks/ai-proposal-round.test.ts
@@ -47,16 +47,14 @@ describe("AI proposal rounds", () => {
       status: "pending",
     });
 
-    const results = await resolveAiProposalRound(
+    const decisions = await resolveAiProposalRound(
       [commandCall],
       round,
       () => false,
     );
-    expect(JSON.parse(results[0]!.content)).toMatchObject({
-      decision: "approved_and_completed",
-      exitCode: 0,
-      ok: true,
-      output: "active",
+    expect(decisions[0]).toEqual({
+      callId: "command-1",
+      kind: "execution_completed",
     });
   });
 
@@ -66,8 +64,9 @@ describe("AI proposal rounds", () => {
     const duplicate = prepare([commandCall], proposedCommands);
 
     expect(duplicate.commandProposals).toHaveLength(0);
-    expect(JSON.parse(duplicate.proposalResults.get(commandCall.id)!.content))
-      .toMatchObject({ ok: false, error: "AI 重复返回了同一条终端命令" });
+    expect(duplicate.proposalErrors.get(commandCall.id)).toBe(
+      "AI 重复返回了同一条终端命令",
+    );
   });
 
   test("rejects tool calls outside the proposal protocol", () => {

--- a/src/hooks/ai-proposal-round.ts
+++ b/src/hooks/ai-proposal-round.ts
@@ -1,23 +1,18 @@
 import {
-  aiCommandApprovalToolResult,
-  aiCommandProposalToolResult,
   createAiCommandProposal,
   isAiCommandProposalToolCall,
   type AiCommandApprovalDecision,
   type AiCommandProposal,
 } from "../ai-command-proposals";
 import {
-  aiFileApprovalToolResult,
   type AiFileApprovalDecision,
 } from "../ai-file-approvals";
 import {
-  aiFileEditToolResult,
   createAiFileEditProposal,
   isAiFileEditToolCall,
   type AiFileEditProposal,
 } from "../ai-file-edits";
 import {
-  aiFileOperationToolResult,
   createAiFileOperationProposal,
   isAiFileOperationToolCall,
   type AiFileOperationProposal,
@@ -26,7 +21,6 @@ import type { AiRemoteFileContext } from "../ai-utils";
 import {
   commandErrorMessage,
   type AiToolCall,
-  type AiToolResult,
 } from "../tauri-protocol";
 
 interface PrepareAiProposalRoundOptions {
@@ -59,7 +53,17 @@ export interface AiPreparedProposalRound {
   fileApprovalDecisions: Map<string, Promise<AiFileApprovalDecision>>;
   fileEditProposals: AiFileEditProposal[];
   fileOperationProposals: AiFileOperationProposal[];
-  proposalResults: Map<string, AiToolResult>;
+  proposalErrors: Map<string, string>;
+}
+
+export interface AiActionRoundDecision {
+  callId: string;
+  kind:
+    | AiCommandApprovalDecision["kind"]
+    | AiFileApprovalDecision["kind"]
+    | "invalid";
+  feedback?: string;
+  error?: string;
 }
 
 function assertSupportedProposalCalls(calls: AiToolCall[]) {
@@ -98,7 +102,7 @@ export function prepareAiProposalRound({
     fileApprovalDecisions: new Map(),
     fileEditProposals: [],
     fileOperationProposals: [],
-    proposalResults: new Map(),
+    proposalErrors: new Map(),
   };
 
   for (const call of calls.filter(isAiFileEditToolCall)) {
@@ -124,10 +128,7 @@ export function prepareAiProposalRound({
     } catch (error) {
       proposalError = commandErrorMessage(error);
     }
-    round.proposalResults.set(
-      call.id,
-      aiFileEditToolResult(call, proposalError),
-    );
+    if (proposalError) round.proposalErrors.set(call.id, proposalError);
   }
 
   for (const call of calls.filter(isAiFileOperationToolCall)) {
@@ -157,10 +158,7 @@ export function prepareAiProposalRound({
     } catch (error) {
       proposalError = commandErrorMessage(error);
     }
-    round.proposalResults.set(
-      call.id,
-      aiFileOperationToolResult(call, proposalError),
-    );
+    if (proposalError) round.proposalErrors.set(call.id, proposalError);
   }
 
   for (const call of calls.filter(isAiCommandProposalToolCall)) {
@@ -187,10 +185,7 @@ export function prepareAiProposalRound({
       proposalError = commandErrorMessage(error);
     }
     if (proposalError) {
-      round.proposalResults.set(
-        call.id,
-        aiCommandProposalToolResult(call, proposalError),
-      );
+      round.proposalErrors.set(call.id, proposalError);
     }
   }
 
@@ -211,49 +206,79 @@ export async function resolveAiProposalRound(
   round: AiPreparedProposalRound,
   isCancelled: () => boolean,
 ) {
-  const toolResults: AiToolResult[] = [];
+  const decisions: AiActionRoundDecision[] = [];
 
   for (const call of calls) {
     if (isCancelled()) throw new Error("AI 请求已取消");
 
     if (isAiFileEditToolCall(call)) {
       const decision = round.fileApprovalDecisions.get(call.id);
-      toolResults.push(
-        decision
-          ? aiFileApprovalToolResult(call, await decision)
-          : (round.proposalResults.get(call.id) ??
-              aiFileEditToolResult(call, "文件修改建议未通过本地校验")),
+      const resolved = decision ? await decision : null;
+      decisions.push(
+        resolved
+          ? {
+              callId: call.id,
+              kind: resolved.kind,
+              ...(resolved.kind === "revision_requested"
+                ? { feedback: resolved.feedback }
+                : {}),
+            }
+          : {
+              callId: call.id,
+              error:
+                round.proposalErrors.get(call.id) ??
+                "文件修改建议未通过本地校验",
+              kind: "invalid",
+            },
       );
       continue;
     }
     if (isAiFileOperationToolCall(call)) {
       const decision = round.fileApprovalDecisions.get(call.id);
-      toolResults.push(
-        decision
-          ? aiFileApprovalToolResult(call, await decision)
-          : (round.proposalResults.get(call.id) ??
-              aiFileOperationToolResult(
-                call,
+      const resolved = decision ? await decision : null;
+      decisions.push(
+        resolved
+          ? {
+              callId: call.id,
+              kind: resolved.kind,
+              ...(resolved.kind === "revision_requested"
+                ? { feedback: resolved.feedback }
+                : {}),
+            }
+          : {
+              callId: call.id,
+              error:
+                round.proposalErrors.get(call.id) ??
                 "文件操作建议未通过本地校验",
-              )),
+              kind: "invalid",
+            },
       );
       continue;
     }
     if (isAiCommandProposalToolCall(call)) {
       const decision = round.commandApprovalDecisions.get(call.id);
-      toolResults.push(
-        decision
-          ? aiCommandApprovalToolResult(call, await decision)
-          : (round.proposalResults.get(call.id) ??
-              aiCommandProposalToolResult(
-                call,
+      const resolved = decision ? await decision : null;
+      decisions.push(
+        resolved
+          ? {
+              callId: call.id,
+              kind: resolved.kind,
+              ...(resolved.kind === "revision_requested"
+                ? { feedback: resolved.feedback }
+                : {}),
+            }
+          : {
+              callId: call.id,
+              error:
+                round.proposalErrors.get(call.id) ??
                 "终端命令建议未通过本地校验",
-              )),
+              kind: "invalid",
+            },
       );
       continue;
     }
     throw new Error(`AI 请求了不支持的工具：${call.name}`);
   }
 
-  return toolResults;
+  return decisions;
 }

--- a/src/hooks/useAiRequestOrchestrator.test.tsx
+++ b/src/hooks/useAiRequestOrchestrator.test.tsx
@@ -657,14 +657,16 @@ describe("useAiRequestOrchestrator", () => {
     const restoredTask = agentTask("task-restored", "completed", 5);
     const replayedTask = agentTask("task-restored", "failed", 6);
     const invoke = mock(async (command: string) => {
-      if (command === "ai_task_get") return restoredTask;
-      if (command === "ai_task_events_since") {
-        return [{
+      if (command === "ai_task_sync") {
+        return {
+          task: restoredTask,
+          events: [{
           kind: "task_failed",
           protocolVersion: PROTOCOL_VERSION,
           sequence: 6,
           task: replayedTask,
-        }];
+          }],
+        };
       }
       throw new Error(`unexpected command: ${command}`);
     }) as unknown as AiRequestInvoke;
@@ -703,8 +705,9 @@ describe("useAiRequestOrchestrator", () => {
   test("drops a restored task when the terminal session changes", async () => {
     const restoredTask = agentTask("task-restored", "paused", 5);
     const invoke = mock(async (command: string) => {
-      if (command === "ai_task_get") return restoredTask;
-      if (command === "ai_task_events_since") return [];
+      if (command === "ai_task_sync") {
+        return { task: restoredTask, events: [] };
+      }
       throw new Error(`unexpected command: ${command}`);
     }) as unknown as AiRequestInvoke;
     const callbacks = createConversationCallbacks();

--- a/src/hooks/useAiRequestOrchestrator.test.tsx
+++ b/src/hooks/useAiRequestOrchestrator.test.tsx
@@ -149,6 +149,20 @@ describe("useAiRequestOrchestrator", () => {
     const requests: Array<{ toolRounds: unknown[] }> = [];
     const invokeMock = mock(
       async (command: string, args?: Record<string, unknown>) => {
+        if (command === "ai_task_action_results") {
+          const request = args?.request as {
+            calls: Array<{ id: string; name: string }>;
+          };
+          return request.calls.map((call) => ({
+            callId: call.id,
+            content: JSON.stringify({
+              decision: "approved_and_completed",
+              message: "远程文件已更新",
+              ok: true,
+            }),
+            name: call.name,
+          }));
+        }
         if (command !== "ai_chat_start") {
           throw new Error(`unexpected command: ${command}`);
         }
@@ -256,6 +270,20 @@ describe("useAiRequestOrchestrator", () => {
     }> = [];
     const invoke = mock(
       async (command: string, args?: Record<string, unknown>) => {
+        if (command === "ai_task_action_results") {
+          return [
+            {
+              callId: "command-approval-1",
+              content: JSON.stringify({
+                decision: "approved_and_completed",
+                exitCode: 0,
+                ok: true,
+                output: "Mem: 1.8Gi used, 2.0Gi free",
+              }),
+              name: "propose_terminal_command",
+            },
+          ];
+        }
         if (command !== "ai_chat_start") {
           throw new Error(`unexpected command: ${command}`);
         }
@@ -362,7 +390,7 @@ describe("useAiRequestOrchestrator", () => {
       await send;
     });
 
-    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledTimes(3);
     expect(requests[1]!.toolRounds[0]!.reasoningContent).toBe(
       "inspect service state before continuing",
     );
@@ -396,6 +424,22 @@ describe("useAiRequestOrchestrator", () => {
     }> = [];
     const invoke = mock(
       async (command: string, args?: Record<string, unknown>) => {
+        if (command === "ai_task_action_results") {
+          const request = args?.request as {
+            decisions: Array<{ feedback?: string }>;
+          };
+          return [
+            {
+              callId: "command-revision-1",
+              content: JSON.stringify({
+                decision: "revision_requested",
+                feedback: request.decisions[0]?.feedback,
+                ok: false,
+              }),
+              name: "propose_terminal_command",
+            },
+          ];
+        }
         if (command !== "ai_chat_start") {
           throw new Error(`unexpected command: ${command}`);
         }
@@ -471,7 +515,7 @@ describe("useAiRequestOrchestrator", () => {
       await send;
     });
 
-    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledTimes(3);
     expect(JSON.parse(requests[1]!.toolRounds[0]!.results[0]!.content)).toEqual(
       expect.objectContaining({
         decision: "revision_requested",

--- a/src/hooks/useAiRequestOrchestrator.ts
+++ b/src/hooks/useAiRequestOrchestrator.ts
@@ -21,6 +21,7 @@ import {
   type AgentTaskEventPayload,
   type AgentTaskRecoveryContext,
   type AgentTaskRecoveryDecision,
+  type AgentTaskSync,
   type AiChatResult,
   type AiRequestTelemetry,
   type AiStreamPayload,
@@ -32,6 +33,10 @@ import {
   agentTaskIsTerminal,
   mergeAgentPlanIntoMessage,
 } from "./ai-agent-plan-presentation";
+import {
+  applyAgentTaskEvent,
+  reconcileAgentTaskSync,
+} from "./agent-task-event-state";
 import {
   aiProposalRoundHasPendingApprovals,
   prepareAiProposalRound,
@@ -186,6 +191,7 @@ export function useAiRequestOrchestrator({
 }: UseAiRequestOrchestratorOptions) {
   const [sending, setSending] = useState(false);
   const [activeTask, setActiveTask] = useState<AgentTask>();
+  const activeTaskRef = useRef<AgentTask>();
   const activeRequestRef = useRef<ActiveAiRequest>();
   const trackedTaskIdRef = useRef<string>();
   const cancelledRequestsRef = useRef(new Set<string>());
@@ -222,6 +228,39 @@ export function useAiRequestOrchestrator({
     waitForCommandApproval,
     waitForFileApproval,
   } = useAiProposalApprovals();
+
+  const commitActiveTask = useCallback((task: AgentTask | undefined) => {
+    activeTaskRef.current = task;
+    setActiveTask(task);
+  }, []);
+
+  const projectTaskPlan = useCallback(
+    (task: AgentTask, activeRequest: ActiveAiRequest | undefined) => {
+      const plan = task.plan;
+      if (!plan || !activeRequest) return;
+      backendDiagnosticPlanTasksRef.current.set(plan.id, task.id);
+      activeDiagnosticPlansRef.current.set(plan.id, {
+        conversationId: activeRequest.conversationId,
+        hostId: activeRequest.hostId,
+        messageId: activeRequest.assistantId,
+      });
+      callbacksRef.current.updateMessages(
+        activeRequest.hostId,
+        activeRequest.conversationId,
+        (messages) =>
+          messages.map((message) =>
+            message.id === activeRequest.assistantId
+              ? mergeAgentPlanIntoMessage(message, plan)
+              : message,
+          ),
+      );
+      if (["completed", "partial", "cancelled"].includes(plan.status)) {
+        activeDiagnosticPlansRef.current.delete(plan.id);
+        stoppedDiagnosticPlansRef.current.delete(plan.id);
+      }
+    },
+    [],
+  );
 
   const cancelRequest = useCallback(async () => {
     const requestId = activeRequestRef.current?.requestId;
@@ -341,12 +380,13 @@ export function useAiRequestOrchestrator({
     activeDiagnosticPlansRef.current.clear();
     backendDiagnosticPlanTasksRef.current.clear();
     stoppedDiagnosticPlansRef.current.clear();
-    setActiveTask(undefined);
+    commitActiveTask(undefined);
     setSending(false);
   }, [
     invoke,
     rejectPendingCommandApprovals,
     rejectPendingFileApprovals,
+    commitActiveTask,
     sessionId,
   ]);
 
@@ -387,40 +427,15 @@ export function useAiRequestOrchestrator({
     void listenToTaskEvents((payload) => {
       const activeRequest = activeRequestRef.current;
       const trackedTaskId = activeRequest?.requestId ?? trackedTaskIdRef.current;
-      if (!trackedTaskId || payload.task.id !== trackedTaskId) return;
-      setActiveTask((current) => {
-        if (
-          current?.id === payload.task.id &&
-          current.lastEventSequence >= payload.sequence
-        ) {
-          return current;
-        }
-        return payload.task;
-      });
-      const plan = payload.task.plan;
-      if (plan && activeRequest) {
-        backendDiagnosticPlanTasksRef.current.set(plan.id, payload.task.id);
-        activeDiagnosticPlansRef.current.set(plan.id, {
-          conversationId: activeRequest.conversationId,
-          hostId: activeRequest.hostId,
-          messageId: activeRequest.assistantId,
-        });
-        callbacksRef.current.updateMessages(
-          activeRequest.hostId,
-          activeRequest.conversationId,
-          (messages) =>
-            messages.map((message) =>
-              message.id === activeRequest.assistantId
-                ? mergeAgentPlanIntoMessage(message, plan)
-                : message,
-            ),
-        );
-        if (["completed", "partial", "cancelled"].includes(plan.status)) {
-          activeDiagnosticPlansRef.current.delete(plan.id);
-          stoppedDiagnosticPlansRef.current.delete(plan.id);
-        }
-      }
-      if (agentTaskIsTerminal(payload.task)) setSending(false);
+      const next = applyAgentTaskEvent(
+        activeTaskRef.current,
+        trackedTaskId,
+        payload,
+      );
+      if (!next || next === activeTaskRef.current) return;
+      commitActiveTask(next);
+      projectTaskPlan(next, activeRequest);
+      if (agentTaskIsTerminal(next)) setSending(false);
     })
       .then((unlisten) => {
         if (disposed) unlisten();
@@ -431,50 +446,42 @@ export function useAiRequestOrchestrator({
       disposed = true;
       stopTaskEvents?.();
     };
-  }, [listenToTaskEvents]);
+  }, [commitActiveTask, listenToTaskEvents, projectTaskPlan]);
 
   useEffect(() => {
     if (!restoreTaskId) {
       if (!activeRequestRef.current) {
         trackedTaskIdRef.current = undefined;
-        setActiveTask(undefined);
+        commitActiveTask(undefined);
       }
       return;
     }
     trackedTaskIdRef.current = restoreTaskId;
     let disposed = false;
-    void invoke<AgentTask | null>("ai_task_get", { taskId: restoreTaskId })
-      .then(async (task) => {
-        if (!task) return null;
-        let replayed: AgentTaskEventPayload[];
-        try {
-          replayed = await invoke<AgentTaskEventPayload[]>(
-            "ai_task_events_since",
-            { taskId: task.id, afterSequence: task.lastEventSequence },
-          );
-        } catch {
-          return task;
-        }
-        return replayed.reduce(
-          (latest, event) =>
-            event.sequence > latest.lastEventSequence ? event.task : latest,
-          task,
+    const currentSequence =
+      activeTaskRef.current?.id === restoreTaskId
+        ? activeTaskRef.current.lastEventSequence
+        : 0;
+    void invoke<AgentTaskSync>("ai_task_sync", {
+      taskId: restoreTaskId,
+      afterSequence: currentSequence,
+    })
+      .then((sync) => {
+        if (disposed || trackedTaskIdRef.current !== restoreTaskId) return;
+        const next = reconcileAgentTaskSync(
+          activeTaskRef.current,
+          restoreTaskId,
+          sync,
         );
-      })
-      .then((task) => {
-        if (disposed || !task || trackedTaskIdRef.current !== task.id) return;
-        setActiveTask((current) =>
-          current?.id === task.id &&
-          current.lastEventSequence > task.lastEventSequence
-            ? current
-            : task,
-        );
+        if (!next || next === activeTaskRef.current) return;
+        commitActiveTask(next);
+        projectTaskPlan(next, activeRequestRef.current);
       })
       .catch(() => undefined);
     return () => {
       disposed = true;
     };
-  }, [invoke, restoreTaskId]);
+  }, [commitActiveTask, invoke, projectTaskPlan, restoreTaskId]);
 
   const sendMessage = useCallback(
     async ({
@@ -532,7 +539,7 @@ export function useAiRequestOrchestrator({
         messages: [...history, userMessage, assistantMessage],
       }));
       setDraft(targetConversationId, "");
-      setActiveTask(undefined);
+      commitActiveTask(undefined);
       setSending(true);
       cancelledRequestsRef.current.delete(requestId);
       let requestTelemetry: AiRequestTelemetry | undefined;
@@ -779,6 +786,7 @@ export function useAiRequestOrchestrator({
     },
     [
       approvalMode,
+      commitActiveTask,
       invoke,
       persistConversation,
       queueConversationSummary,

--- a/src/hooks/useAiRequestOrchestrator.ts
+++ b/src/hooks/useAiRequestOrchestrator.ts
@@ -670,10 +670,20 @@ export function useAiRequestOrchestrator({
           if (aiProposalRoundHasPendingApprovals(proposalRound)) {
             await persistConversation(proposalConversation);
           }
-          const toolResults = await resolveAiProposalRound(
+          const decisions = await resolveAiProposalRound(
             result.toolCalls,
             proposalRound,
             () => cancelledRequestsRef.current.has(requestId),
+          );
+          const toolResults = await invoke<AiToolRound["results"]>(
+            "ai_task_action_results",
+            {
+              request: {
+                taskId: requestId,
+                calls: result.toolCalls,
+                decisions,
+              },
+            },
           );
           toolRounds.push({
             calls: result.toolCalls,

--- a/src/styles/app-windows.css
+++ b/src/styles/app-windows.css
@@ -779,18 +779,11 @@
 .host-tree-table-container {
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow: hidden;
 }
 
-.host-tree-table .arco-table-content-scroll {
-  overflow: visible;
-}
-
-.host-tree-table thead > .arco-table-tr > .arco-table-th {
-  position: sticky;
-  top: 0;
-  z-index: 3;
-  background: var(--color-fill-1);
+.host-tree-table .arco-table-body {
+  height: var(--host-table-body-height);
 }
 
 .manager-toolbar-actions {

--- a/src/tauri-protocol.test.ts
+++ b/src/tauri-protocol.test.ts
@@ -30,7 +30,7 @@ describe("Tauri shared protocol", () => {
     expect(PROTOCOL_VERSION).toBe(contract.version);
     expect(contract.commands[command]).toBe(true);
     expect(contract.events[event]).toBe(true);
-    expect(Object.keys(contract.commands)).toHaveLength(88);
+    expect(Object.keys(contract.commands)).toHaveLength(89);
     expect(Object.keys(contract.events)).toHaveLength(11);
   });
 

--- a/src/tauri-protocol.test.ts
+++ b/src/tauri-protocol.test.ts
@@ -30,7 +30,7 @@ describe("Tauri shared protocol", () => {
     expect(PROTOCOL_VERSION).toBe(contract.version);
     expect(contract.commands[command]).toBe(true);
     expect(contract.events[event]).toBe(true);
-    expect(Object.keys(contract.commands)).toHaveLength(89);
+    expect(Object.keys(contract.commands)).toHaveLength(90);
     expect(Object.keys(contract.events)).toHaveLength(11);
   });
 

--- a/src/tauri-protocol.ts
+++ b/src/tauri-protocol.ts
@@ -316,6 +316,11 @@ export interface AgentTaskEventPayload {
   task: AgentTask;
 }
 
+export interface AgentTaskSync {
+  task: AgentTask | null;
+  events: AgentTaskEventPayload[];
+}
+
 export interface AgentTaskRecoveryContext {
   previousTaskId: string;
   hostId: string;


### PR DESCRIPTION
## 变更内容

- 修复混合诊断与动作工具调用的恢复流程
- 收敛原生 Tool Call 与 DSML 降级协议，避免重复解析
- 将动作审批与执行轮次迁移到 Rust Agent Runtime
- 统一 Agent 事件同步与任务恢复协议
- 将未知工具和无效参数转为可恢复 ToolResult
- 统一 Rust 与 TypeScript 工具契约和标签来源
- 修复首页主机列表滚动区域与固定表头布局
- 补齐编排、事件回放和协议一致性回归测试

## 验证

- Rust：183 passed，8 ignored（在线环境测试）
- 前端：425 passed
- cargo clippy --all-targets --all-features -- -D warnings
- bun run build